### PR TITLE
EA-0 make BWellSDK a singleton

### DIFF
--- a/bwell-kotlin-android/README.md
+++ b/bwell-kotlin-android/README.md
@@ -47,7 +47,7 @@ In the same file ensure that the minSdk level is set to 24.
 ## Import the SDK and Use It
 ```
 // BWell SDK Usage
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 
 val helloStr = BWellSdk.hello()
 ```

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/MainActivity.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/MainActivity.kt
@@ -16,11 +16,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.lifecycleScope
 import com.bwell.sampleapp.ui.theme.MyTestAppTheme
 // BWell SDK Usage
-import com.bwell.BWellSdk
 import com.bwell.core.network.auth.Credentials
 import com.bwell.core.config.BWellConfig
 import com.bwell.core.config.LogLevel
 import com.bwell.core.config.RetryPolicy
+import com.bwell.sampleapp.singletons.BWellSdk
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsummary/HealthSummaryCategoriesDataAdapter.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsummary/HealthSummaryCategoriesDataAdapter.kt
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.common.models.domain.common.Coding
 import com.bwell.common.models.domain.healthdata.healthsummary.allergyintolerance.AllergyIntoleranceGroup
 import com.bwell.common.models.domain.healthdata.healthsummary.careplan.CarePlanGroup

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/login/LoginFragment.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/login/LoginFragment.kt
@@ -11,7 +11,7 @@ import android.widget.ProgressBar
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.core.config.BWellConfig
 import com.bwell.core.config.KeyStoreConfig
 import com.bwell.core.config.LogLevel

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/ClinicsRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/ClinicsRepository.kt
@@ -1,7 +1,7 @@
 package com.bwell.sampleapp.repository
 
 import android.content.Context
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.common.models.domain.search.Provider
 import com.bwell.common.models.responses.BWellResult
 import com.bwell.search.requests.provider.ProviderSearchRequest

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/DataConnectionLabsRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/DataConnectionLabsRepository.kt
@@ -1,7 +1,7 @@
 package com.bwell.sampleapp.repository
 
 import android.content.Context
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.common.models.domain.search.Provider
 import com.bwell.common.models.responses.BWellResult
 import com.bwell.search.requests.provider.ProviderSearchRequest

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/DataConnectionsRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/DataConnectionsRepository.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.common.models.domain.consent.Consent
 import com.bwell.common.models.domain.data.Connection
 import com.bwell.common.models.domain.data.DataSource

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/HealthJourneyRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/HealthJourneyRepository.kt
@@ -1,6 +1,6 @@
 package com.bwell.sampleapp.repository
 
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.activity.requests.TasksRequest
 import com.bwell.common.models.domain.task.Task
 import com.bwell.common.models.responses.BWellResult

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/HealthSummaryRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/HealthSummaryRepository.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.common.models.domain.healthdata.healthsummary.healthsummary.HealthSummary
 import com.bwell.common.models.domain.healthdata.healthsummary.healthsummary.enums.HealthSummaryCategory
 import com.bwell.common.models.responses.BWellResult

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/LabsRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/LabsRepository.kt
@@ -1,7 +1,7 @@
 package com.bwell.sampleapp.repository
 
 import android.content.Context
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.common.models.domain.healthdata.lab.LabGroup
 import com.bwell.common.models.domain.healthdata.lab.LabKnowledge
 import com.bwell.common.models.domain.healthdata.observation.Observation

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/MedicineRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/MedicineRepository.kt
@@ -1,7 +1,7 @@
 package com.bwell.sampleapp.repository
 
 import android.content.Context
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.common.models.domain.healthdata.medication.MedicationGroup
 import com.bwell.common.models.domain.healthdata.medication.MedicationKnowledge
 import com.bwell.common.models.domain.healthdata.medication.MedicationStatement
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.flow
 
 class MedicineRepository(private val applicationContext: Context) {
 
-    suspend fun getMedicationGroups(medicationRequest: MedicationGroupsRequest): Flow<BWellResult<MedicationGroup>?> = flow {
+    suspend fun getMedicationGroups(medicationRequest: MedicationGroupsRequest?): Flow<BWellResult<MedicationGroup>?> = flow {
         try {
             val medicationGroupsResult = BWellSdk.health?.getMedicationGroups(medicationRequest)
             emit(medicationGroupsResult)

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/ProviderRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/ProviderRepository.kt
@@ -1,6 +1,6 @@
 package com.bwell.sampleapp.repository
 
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.common.models.domain.search.Provider
 import com.bwell.common.models.responses.BWellResult
 import com.bwell.common.models.responses.OperationOutcome

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/Repository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/Repository.kt
@@ -3,7 +3,7 @@ package com.bwell.sampleapp.repository
 import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import com.bwell.BWellSdk
+import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.common.models.domain.user.Person
 import com.bwell.common.models.responses.BWellResult
 import com.bwell.common.models.responses.OperationOutcome

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/singletons/BWellSDK.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/singletons/BWellSDK.kt
@@ -1,0 +1,3 @@
+package com.bwell.sampleapp.singletons
+
+typealias BWellSdk = com.bwell.BWellSdk

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/viewmodel/MedicinesViewModel.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/viewmodel/MedicinesViewModel.kt
@@ -18,11 +18,7 @@ class MedicinesViewModel(private val repository: MedicineRepository?) : ViewMode
     private val _activeMedicationResults = MutableStateFlow<BWellResult<MedicationGroup>?>(null)
     val activeMedicationResults: StateFlow<BWellResult<MedicationGroup>?> = _activeMedicationResults
 
-<<<<<<< Updated upstream
     fun getActiveMedicationGroups(medicationRequest: MedicationGroupsRequest) {
-=======
-    fun getMedicationGroups(medicationRequest: MedicationGroupsRequest?) {
->>>>>>> Stashed changes
         viewModelScope.launch {
             try {
                 repository?.getMedicationGroups(medicationRequest)?.collect { result ->

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/viewmodel/MedicinesViewModel.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/viewmodel/MedicinesViewModel.kt
@@ -18,7 +18,11 @@ class MedicinesViewModel(private val repository: MedicineRepository?) : ViewMode
     private val _activeMedicationResults = MutableStateFlow<BWellResult<MedicationGroup>?>(null)
     val activeMedicationResults: StateFlow<BWellResult<MedicationGroup>?> = _activeMedicationResults
 
+<<<<<<< Updated upstream
     fun getActiveMedicationGroups(medicationRequest: MedicationGroupsRequest) {
+=======
+    fun getMedicationGroups(medicationRequest: MedicationGroupsRequest?) {
+>>>>>>> Stashed changes
         viewModelScope.launch {
             try {
                 repository?.getMedicationGroups(medicationRequest)?.collect { result ->


### PR DESCRIPTION
seems like different instances of the BWellSdk were being used for authentication and retrieving resources. 

e.g retrieving `getMedicationGroups` was causing this error:

```
 ResourceCollection(data=null, pagingInfo=null, error=BWellError(exception=java.lang.IllegalArgumentException: The TokenRepository contains a null access token, an authentication is required, serverErrors=null))
```

This PR ensures that the sample app is using 1 instance of the BWellSdk