### PR TITLE
DCON-1439 Integrated Activate button for activateDirectConnection in example app

### DIFF
--- a/bwell-kotlin-android/app/build.gradle.kts
+++ b/bwell-kotlin-android/app/build.gradle.kts
@@ -69,7 +69,7 @@ android {
 dependencies {
 
     // BWell SDK Usage
-    implementation("com.bwell:bwell-sdk-kotlin:1.8.0")
+    implementation("com.bwell:bwell-sdk-kotlin:1.9.0")
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/data_connections/DataConnectionsFragment.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/data_connections/DataConnectionsFragment.kt
@@ -16,6 +16,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bwell.common.models.domain.common.Organization
 import com.bwell.common.models.domain.data.Connection
+import com.bwell.common.models.domain.data.enums.ConnectionCategory
+import com.bwell.common.models.domain.data.enums.ConnectionStatus
 import com.bwell.common.models.responses.BWellResult
 import com.bwell.connections.requests.ConnectionCreateRequest
 import com.bwell.sampleapp.BWellSampleApplication
@@ -439,10 +441,10 @@ class DataConnectionsFragment : Fragment(), View.OnClickListener,
                 this.frameLayoutConnectionStatus = frameLayoutConnectionStatus
                 
                 // Show/hide buttons based on connection category and status
-                val category = item.category.toString()
-                val connectionStatus = item.status.toString()
+                val category = item.category
+                val connectionStatus = item.status
                 
-                if (category == "IDENTITY" && connectionStatus == "DISCONNECTED") {
+                if (category == ConnectionCategory.IDENTITY && connectionStatus == ConnectionStatus.DISCONNECTED) {
                     // Show activate button, hide disconnect button
                     showActivateButton()
                 } else {

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/data_connections/DataConnectionsFragment.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/data_connections/DataConnectionsFragment.kt
@@ -295,7 +295,7 @@ class DataConnectionsFragment : Fragment(), View.OnClickListener,
                             if (activateOutcome.success()) {
                                 val drawable = ContextCompat.getDrawable(
                                     requireContext(),
-                                    R.drawable.rounded_rectangle_green
+                                    R.drawable.rounded_rectangle_grey
                                 )
                                 frameLayoutConnectionStatus.background = drawable
                                 if (frameLayoutConnectionStatus.childCount > 0 && frameLayoutConnectionStatus.getChildAt(
@@ -307,7 +307,7 @@ class DataConnectionsFragment : Fragment(), View.OnClickListener,
                                     textView.text = resources.getString(R.string.activated)
                                     textView.setTextColor(
                                         resources.getColor(
-                                            R.color.white,
+                                            R.color.black,
                                             context?.theme
                                         )
                                     )

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/DataConnectionsRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/DataConnectionsRepository.kt
@@ -74,6 +74,16 @@ class DataConnectionsRepository(private val applicationContext: Context) {
         }
     }
 
+    suspend fun activateDirectConnection(connectionId: String): Flow<OperationOutcome?> = flow {
+        try {
+            val activateOutcome = BWellSdk.connections.activateDirectConnection(connectionId)
+            emit(activateOutcome)
+        } catch (e: Exception) {
+            // Handle exceptions, if any
+            emit(null)
+        }
+    }
+
     suspend fun deleteConnection(connectionId: String): Flow<OperationOutcome?> = flow {
         try {
             val deleteOutcome = BWellSdk.connections.deleteConnection(connectionId)

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/viewmodel/DataConnectionsViewModel.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/viewmodel/DataConnectionsViewModel.kt
@@ -126,6 +126,21 @@ class DataConnectionsViewModel(
         }
     }
 
+    private val _activateConnectionData = MutableStateFlow<OperationOutcome?>(null)
+    val activateConnectionData: StateFlow<OperationOutcome?> = _activateConnectionData
+
+    fun activateDirectConnection(connectionId: String) {
+        viewModelScope.launch {
+            try {
+                repository?.activateDirectConnection(connectionId)?.collect { activateOutcome ->
+                    _activateConnectionData.emit(activateOutcome)
+                }
+            } catch (ex: Exception) {
+                Log.i(TAG, ex.toString())
+            }
+        }
+    }
+
     private val _deleteConnectionData = MutableStateFlow<OperationOutcome?>(null)
     val deleteConnectionData: StateFlow<OperationOutcome?> = _deleteConnectionData
 

--- a/bwell-kotlin-android/app/src/main/res/layout/fragment_data_connections.xml
+++ b/bwell-kotlin-android/app/src/main/res/layout/fragment_data_connections.xml
@@ -84,6 +84,15 @@
             android:layout_margin="5dp"
             android:textSize="12sp"/>
         <TextView
+            android:id="@+id/activate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/activate"
+            android:layout_gravity="left"
+            android:textStyle="bold"
+            android:layout_margin="5dp"
+            android:textSize="12sp"/>
+        <TextView
             android:id="@+id/delete"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/bwell-kotlin-android/app/src/main/res/values/strings.xml
+++ b/bwell-kotlin-android/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="previous">Previous</string>
     <string name="disconnect">Disconnect</string>
     <string name="delete">Delete</string>
+    <string name="activate">Activate</string>
 
     <string name="lorem_ipsum">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam in scelerisque sem. Mauris
@@ -214,6 +215,7 @@
     <string name="clinic_info_hapi">By providing my %s credentials, I consent for b.well to retrieve my health data.</string>
     <string name="disconnected">Disconnected</string>
     <string name="deleted">Deleted</string>
+    <string name="activated">Connected</string>
     <string name="procedures">Procedures</string>
     <string name="vitals">Vitals</string>
     <string name="visit_history">Visit History</string>


### PR DESCRIPTION
Implemented Toggle button support for Direct IAS connections. When direct connection is disconnected, `Activate` button will show up and for other statuses of direct connection, `Disconnect` button will show up.

**Activate:**
<img width="302" height="662" alt="Screenshot 2025-09-29 at 3 43 00 PM" src="https://github.com/user-attachments/assets/50aa3892-1ff0-4192-9181-9a929f1e1d50" />
**Disconnect:**
<img width="305" height="671" alt="Screenshot 2025-09-29 at 3 42 30 PM" src="https://github.com/user-attachments/assets/2783925a-2b5d-4e18-ba7a-6872b0f409a0" />

**Note**: To toggle the button the connection state need to be updated for which refresh is required.

API call response:
**a. In case of success:**
<img width="1470" height="956" alt="Screenshot 2025-09-29 at 3 49 47 PM" src="https://github.com/user-attachments/assets/a5c516e6-4cec-43c6-88d7-a21ff470cc25" />
b. In case of **failure:**
<img width="1470" height="956" alt="Screenshot 2025-09-29 at 3 49 33 PM" src="https://github.com/user-attachments/assets/58567854-6354-48c6-b4ea-fdfb64fda9a4" />

Recording -

https://github.com/user-attachments/assets/bb4b01aa-8198-42fa-9785-f7f025be7c45

