### PR TITLE
EA-2170 Update Swift iOS example app with new SDK features

### DIFF
--- a/bwell-swift-ios/README.md
+++ b/bwell-swift-ios/README.md
@@ -1,33 +1,75 @@
 # bwell SDK iOS Sample App
 
-This repository contains the example application for iOS demonstrating the capabilities and usage of the b.well SDK.
+This repository contains the example application for iOS demonstrating the capabilities and usage of the b.well Swift SDK.
 
-**note:** The Swift SDK is currently undergoing development and hasn't been released for GA yet so the sample app is not ready for public consumption.
+**Note:** The Swift SDK is currently undergoing development and has not been released for GA yet, so the sample app is not ready for public consumption.
 
-**Features:**
-- Native UI with SwiftUI
-- Authentication flow and credential's presistence with API Key followed Email & Password or JWT Token.
-- Keychain for user's credentials persistence.
-- View and update user's profile information.
-- Health data retrieval.
-- View, Search, and crate connections.
+## Features Demonstrated
 
+### SDK Lifecycle
+- **Initialization** with client key, log level, token storage, and telemetry configuration
+- **Authentication** via email/password credentials (also supports OAuth tokens and auth codes)
+- **Consent creation** (Terms of Service) after authentication
+- **Session validation** with retry logic
+- **Credential persistence** using Keychain
+
+### HealthDataManager
+- **Health Summary** -- aggregated record counts across all FHIR resource categories (allergies, conditions, encounters, immunizations, labs, medications, procedures, vital signs, care plans)
+- **Group views** -- grouped health data with drill-down into individual records
+- **Detail sheets** -- detailed views for each health record type
+- **Goals** -- patient health goals with lifecycle and achievement status (EA-2153)
+
+### SearchManager
+- **Search Providers** -- find healthcare providers and facilities by name, location, and specialty
+- **Submit Provider for Review** -- request addition of a new provider to the directory
+- **OAuth connection flow** -- web-based OAuth for provider connections
+
+### ConnectionManager
+- **Member Connections** -- view connected healthcare providers with sync status
+- **Create Connection** -- establish a new provider connection
+- **Delete/Disconnect** -- manage existing connections
+- **OAuth and basic authentication** connection types
+
+### FinancialManager
+- **Insurance Coverages** -- view coverage records with period and subscriber details
+- **Explanation of Benefits** -- view EOB records with billable periods and claim details
+
+### UserManager
+- **Profile retrieval and update** -- get and modify authenticated user profile
+- **Consent management** -- create and retrieve user consents
+- **Identity verification** -- IAL2 verification flow
+- **Account deletion** -- full account removal
+
+### DeviceManager
+- **Push notification registration** -- register iOS devices for notifications
+
+### Error Handling
+- Typed `SDKError` enum with user-friendly messages and recovery suggestions
+- State machine (`SDKState`) tracking SDK lifecycle
+- Loading state management throughout all views
+
+## Architecture
+
+The example app uses MVVM with SwiftUI and a navigation router:
+
+- `BWellSDKManager` -- SDK lifecycle manager with typed accessors for each manager
+- `NavigationRouter` -- stack-based navigation with `NavigationStack`
+- `SideMenuView` -- side navigation for main sections
+- `HealthSummaryViewModel` -- demonstrates all health data operations including groups
+- `FinancialViewModel` -- demonstrates coverage and EOB retrieval
+- `KeychainTokenStorageAdapter` -- secure token persistence conforming to SDK's `TokenStorage`
 
 ## Set up Instructions
-1. Clone the repository.
-2. Add the SDK as a package dependency
-    a. In Xcode go to File > Add Package Dependencies
-    b. In the search bar enter the SDK's name and add it to the project.
-3. Once the package has been added in the project navigator locate the packge you just added, right click in "Package Dependencies" and click in "Reset Package Caches" and then click in "Resolve Package Versions"
-4. Run the app 
 
-
-Each example includes its own detailed README with specific setup instructions, prerequisites, and usage guidelines.
+1. Clone the repository
+2. Ensure the SDK source is available at `../../bwell-sdk/bwell-sdk-swift` (for local development) or configure SPM to use the package URL
+3. Open `bwell-swift-ios.xcodeproj` in Xcode
+4. Go to File > Packages > Resolve Package Versions
+5. Build and run the app on a simulator or device
 
 ## Common Requirements
 
-iOS Sample App require:
-- Latest MacOS version
-- Valid b.well API credentials
-- Authentication tokens (JWT)
+- macOS 13+ with Xcode 15+
+- iOS 15+ deployment target
+- Valid b.well API credentials (client key, email, password)
 - Network connectivity for API calls

--- a/bwell-swift-ios/bwell-swift-ios.xcodeproj/project.pbxproj
+++ b/bwell-swift-ios/bwell-swift-ios.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		55F2035B2EC4FE42001DA1E8 /* APIKeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F2035A2EC4FE3A001DA1E8 /* APIKeyService.swift */; };
 		55F2035D2EC504E9001DA1E8 /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F2035C2EC504E3001DA1E8 /* LaunchView.swift */; };
 		A264CBC62EE38945000D0AF7 /* BWellSDK in Frameworks */ = {isa = PBXBuildFile; productRef = A264CBC52EE38945000D0AF7 /* BWellSDK */; };
+		B10000012F00000100000001 /* GoalsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000012F00000100000010 /* GoalsView.swift */; };
+		B10000012F00000100000002 /* FinancialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000012F00000100000020 /* FinancialView.swift */; };
+		B10000012F00000100000003 /* FinancialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000012F00000100000030 /* FinancialViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -131,6 +134,9 @@
 		55E6257E2EB5686B000D3783 /* ManageConnectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageConnectionsView.swift; sourceTree = "<group>"; };
 		55F2035A2EC4FE3A001DA1E8 /* APIKeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyService.swift; sourceTree = "<group>"; };
 		55F2035C2EC504E3001DA1E8 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
+		B10000012F00000100000010 /* GoalsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalsView.swift; sourceTree = "<group>"; };
+		B10000012F00000100000020 /* FinancialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialView.swift; sourceTree = "<group>"; };
+		B10000012F00000100000030 /* FinancialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,6 +201,7 @@
 				5522DCAA2EB037CF00F9BCD7 /* Authentication */,
 				551538712EB25C6A001174F9 /* Profile */,
 				5522DCAF2EB11F9C00F9BCD7 /* Health */,
+				B10000012F00000100000040 /* Financial */,
 				5522DCA82EB037B000F9BCD7 /* SideMenuNavigation */,
 				5551A3AE2EC3ECA700394D59 /* SDKManager */,
 				5551A3A82EC38FA800394D59 /* Keychain */,
@@ -365,6 +372,7 @@
 				55D5DF872EB9459E00D71D99 /* ProceduresView.swift */,
 				55D5DF892EB945A700D71D99 /* VitalSignsView.swift */,
 				55D5DF8B2EB9812F00D71D99 /* EncountersView.swift */,
+				B10000012F00000100000010 /* GoalsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -385,6 +393,31 @@
 				55E6257C2EB56861000D3783 /* ManageConnectionsViewModel.swift */,
 			);
 			path = ManageConnections;
+			sourceTree = "<group>";
+		};
+		B10000012F00000100000040 /* Financial */ = {
+			isa = PBXGroup;
+			children = (
+				B10000012F00000100000050 /* Views */,
+				B10000012F00000100000060 /* ViewModel */,
+			);
+			path = Financial;
+			sourceTree = "<group>";
+		};
+		B10000012F00000100000050 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				B10000012F00000100000020 /* FinancialView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		B10000012F00000100000060 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				B10000012F00000100000030 /* FinancialViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -575,6 +608,9 @@
 				55D5DF842EB9458E00D71D99 /* LabsView.swift in Sources */,
 				5522DCB72EB1532000F9BCD7 /* BWellNavigationBar.swift in Sources */,
 				5551A3A72EC29AEC00394D59 /* HomeView.swift in Sources */,
+				B10000012F00000100000001 /* GoalsView.swift in Sources */,
+				B10000012F00000100000002 /* FinancialView.swift in Sources */,
+				B10000012F00000100000003 /* FinancialViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/bwell-swift-ios/bwell-swift-ios/Financial/ViewModel/FinancialViewModel.swift
+++ b/bwell-swift-ios/bwell-swift-ios/Financial/ViewModel/FinancialViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  FinancialViewModel.swift
+//  bwell-swift-ios
+//
+//  Demonstrates the FinancialManager for insurance coverage and EOB retrieval.
+//
+
+import Foundation
+import BWellSDK
+
+@MainActor
+final class FinancialViewModel: ObservableObject {
+    private let sdkManager: BWellSDKManager
+
+    @Published var coverages: [BWell.Coverage] = []
+    @Published var explanationOfBenefits: [BWell.ExplanationOfBenefit] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    init() {
+        self.sdkManager = .shared
+    }
+
+    // MARK: - Coverages
+
+    func getCoverages() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let request = BWell.CoverageRequest(page: 0, pageSize: 20)
+            let response = try await sdkManager.financial().getCoverages(request)
+            self.coverages = response?.entry?.compactMap { $0.resource } ?? []
+            self.errorMessage = nil
+        } catch {
+            errorMessage = "Failed to fetch coverages: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Explanation of Benefits
+
+    func getExplanationOfBenefits() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let request = BWell.ExplanationOfBenefitRequest(page: 0, pageSize: 20)
+            let response = try await sdkManager.financial().getExplanationOfBenefits(request)
+            self.explanationOfBenefits = response?.entry?.compactMap { $0.resource } ?? []
+            self.errorMessage = nil
+        } catch {
+            errorMessage = "Failed to fetch explanation of benefits: \(error.localizedDescription)"
+        }
+    }
+}

--- a/bwell-swift-ios/bwell-swift-ios/Financial/Views/FinancialView.swift
+++ b/bwell-swift-ios/bwell-swift-ios/Financial/Views/FinancialView.swift
@@ -1,0 +1,143 @@
+//
+//  FinancialView.swift
+//  bwell-swift-ios
+//
+//  Demonstrates FinancialManager: coverages and explanation of benefits.
+//
+
+import SwiftUI
+import BWellSDK
+
+struct FinancialView: View {
+    @StateObject private var viewModel = FinancialViewModel()
+    @Binding var showMenu: Bool
+
+    var body: some View {
+        List {
+            // MARK: - Coverages Section
+            Section(header: Text("Insurance Coverages")) {
+                if viewModel.coverages.isEmpty && !viewModel.isLoading {
+                    Text("No coverage records found")
+                        .foregroundColor(.secondary)
+                        .font(.subheadline)
+                } else {
+                    ForEach(viewModel.coverages, id: \.id) { coverage in
+                        CoverageRowView(coverage: coverage)
+                    }
+                }
+            }
+
+            // MARK: - EOB Section
+            Section(header: Text("Explanation of Benefits")) {
+                if viewModel.explanationOfBenefits.isEmpty && !viewModel.isLoading {
+                    Text("No explanation of benefit records found")
+                        .foregroundColor(.secondary)
+                        .font(.subheadline)
+                } else {
+                    ForEach(viewModel.explanationOfBenefits, id: \.id) { eob in
+                        EOBRowView(eob: eob)
+                    }
+                }
+            }
+
+            if let error = viewModel.errorMessage {
+                Section {
+                    Text(error)
+                        .foregroundColor(.red)
+                        .font(.caption)
+                }
+            }
+        }
+        .bwellNavigationBar(showMenu: $showMenu, navigationTitle: "Financial")
+        .listStyle(.plain)
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView("Loading financial data...")
+            }
+        }
+        .task {
+            if viewModel.coverages.isEmpty {
+                await viewModel.getCoverages()
+            }
+            if viewModel.explanationOfBenefits.isEmpty {
+                await viewModel.getExplanationOfBenefits()
+            }
+        }
+    }
+}
+
+// MARK: - Coverage Row
+private struct CoverageRowView: View {
+    let coverage: BWell.Coverage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(coverage.type?.text ?? "Unknown Coverage")
+                .font(.headline)
+
+            if let status = coverage.status {
+                Text("Status: \(status)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let subscriberId = coverage.subscriberId {
+                Text("Subscriber ID: \(subscriberId)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let period = coverage.period {
+                let start = period.start ?? ""
+                let end = period.end ?? ""
+                if !start.isEmpty || !end.isEmpty {
+                    Text("Period: \(start) - \(end)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - EOB Row
+private struct EOBRowView: View {
+    let eob: BWell.ExplanationOfBenefit
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(eob.type?.text ?? "Explanation of Benefit")
+                .font(.headline)
+
+            if let status = eob.status {
+                Text("Status: \(status)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let use = eob.use {
+                Text("Use: \(use)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let period = eob.billablePeriod {
+                let start = period.start ?? ""
+                let end = period.end ?? ""
+                if !start.isEmpty || !end.isEmpty {
+                    Text("Billable Period: \(start) - \(end)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            if let created = eob.created {
+                Text("Created: \(created)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/bwell-swift-ios/bwell-swift-ios/Health/ViewModel/HealthSummaryViewModel.swift
+++ b/bwell-swift-ios/bwell-swift-ios/Health/ViewModel/HealthSummaryViewModel.swift
@@ -24,6 +24,7 @@ final class HealthSummaryViewModel: ObservableObject {
     @Published var vitalSigns: [BWell.Observation] = []
     @Published var medications: [BWell.MedicationStatement] = []
     @Published var encounters: [BWell.Encounter] = []
+    @Published var goals: [BWell.Goal] = []
 
     // Group Published properties
     @Published var allergyIntoleranceGroups: [BWell.AllergyIntoleranceGroup] = []
@@ -296,6 +297,22 @@ final class HealthSummaryViewModel: ObservableObject {
             }
         )
         self.encounters = encounters
+    }
+
+    // MARK: - Goals (EA-2153)
+    func getGoals() async {
+        guard let sdkManager = sdkManager else { return }
+
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let request = BWell.GoalRequest(page: 0)
+            let response = try await sdkManager.health().getGoals(request)
+            self.goals = response.entry?.compactMap { $0.resource } ?? []
+        } catch {
+            errorMessage = "Failed to fetch goals: \(error.localizedDescription)"
+        }
     }
 }
 

--- a/bwell-swift-ios/bwell-swift-ios/Health/Views/GoalsView.swift
+++ b/bwell-swift-ios/bwell-swift-ios/Health/Views/GoalsView.swift
@@ -1,0 +1,116 @@
+//
+//  GoalsView.swift
+//  bwell-swift-ios
+//
+//  Demonstrates the HealthDataManager.getGoals() operation (EA-2153).
+//
+
+import SwiftUI
+import BWellSDK
+
+struct GoalsView: View {
+    @EnvironmentObject private var viewModel: HealthSummaryViewModel
+
+    var body: some View {
+        List {
+            if viewModel.goals.isEmpty && !viewModel.isLoading {
+                VStack(spacing: 16) {
+                    Image(systemName: "target")
+                        .font(.system(size: 48))
+                        .foregroundColor(.secondary)
+                    Text("No Goals")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                    Text("No health goals found")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 40)
+                .listRowSeparator(.hidden)
+            } else {
+                ForEach(viewModel.goals, id: \.id) { goal in
+                    GoalRowView(goal: goal)
+                }
+            }
+
+            if let error = viewModel.errorMessage {
+                Section {
+                    Text(error)
+                        .foregroundColor(.red)
+                        .font(.caption)
+                }
+            }
+        }
+        .navigationTitle("Goals")
+        .listStyle(.plain)
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+            }
+        }
+        .task {
+            if viewModel.goals.isEmpty {
+                await viewModel.getGoals()
+            }
+        }
+    }
+}
+
+// MARK: - Goal Row
+private struct GoalRowView: View {
+    let goal: BWell.Goal
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(goal.description?.text ?? "Unknown Goal")
+                .font(.headline)
+
+            if let status = goal.lifecycleStatus {
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(statusColor(status))
+                        .frame(width: 8, height: 8)
+                    Text("Status: \(status)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            if let achievement = goal.achievementStatus?.text {
+                Text("Achievement: \(achievement)")
+                    .font(.caption)
+                    .foregroundColor(.accentColor)
+            }
+
+            if let category = goal.category?.first?.text {
+                Text("Category: \(category)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let startDate = goal.startDate {
+                Text("Start: \(startDate)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let statusReason = goal.statusReason {
+                Text("Reason: \(statusReason)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func statusColor(_ status: String) -> Color {
+        switch status.lowercased() {
+        case "active": return .green
+        case "completed": return .blue
+        case "cancelled": return .red
+        case "on-hold": return .orange
+        default: return .gray
+        }
+    }
+}

--- a/bwell-swift-ios/bwell-swift-ios/Health/Views/HealthSummaryView.swift
+++ b/bwell-swift-ios/bwell-swift-ios/Health/Views/HealthSummaryView.swift
@@ -17,6 +17,21 @@ struct HealthSummaryView: View {
 
     var body: some View {
         List {
+            // Goals (EA-2153 new operation, not in health summary counts)
+            NavigationLink(destination: GoalsView().environmentObject(viewModel)) {
+                HStack(spacing: 12) {
+                    Image(systemName: "target")
+                        .frame(width: 24, alignment: .center)
+                    Text("Goals")
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .frame(width: 24)
+                        .foregroundStyle(.gray)
+                }
+            }
+            .listRowSeparator(.hidden)
+
             ForEach(HealthDataSummaryModel.allCases) { item in
                 Button {
                     router.path.append(item)

--- a/bwell-swift-ios/bwell-swift-ios/SDKManager/BWellSDKManager.swift
+++ b/bwell-swift-ios/bwell-swift-ios/SDKManager/BWellSDKManager.swift
@@ -33,7 +33,12 @@ final class BWellSDKManager: ObservableObject {
         self.state = .initializing
         do {
             let tokenStorage = KeychainTokenStorageAdapter()
-            let config = BWell.SDKConfig(clientKey: apiKey, logLevel: .verbose,tokenStorage: tokenStorage)
+            let config = BWell.SDKConfig(
+                clientKey: apiKey,
+                logLevel: .verbose,
+                tokenStorage: tokenStorage,
+                telemetry: BWell.TelemetryConfig(enabled: true)
+            )
             let sdkInstance = try BWellSDK(config: config)
 
             try await sdkInstance.initialize()
@@ -206,5 +211,13 @@ extension BWellSDKManager {
         }
 
         return user
+    }
+
+    func financial() throws -> FinancialManager {
+        guard let financial = sdk?.financial else {
+            throw SDKError.notInitialized
+        }
+
+        return financial
     }
 }

--- a/bwell-swift-ios/bwell-swift-ios/SideMenuNavigation/SideMenuOptionModel.swift
+++ b/bwell-swift-ios/bwell-swift-ios/SideMenuNavigation/SideMenuOptionModel.swift
@@ -12,6 +12,7 @@ enum SideMenuOptionModel: Int, CaseIterable {
     case profile
     case manageConnections
     case healthSummary
+    case financial
     case logout
 
 
@@ -21,6 +22,7 @@ enum SideMenuOptionModel: Int, CaseIterable {
             case .profile: "Profile"
             case .manageConnections: "Manage Connections"
             case .healthSummary: "Health Summary"
+            case .financial: "Financial"
             case .logout: "Logout"
         }
     }
@@ -31,6 +33,7 @@ enum SideMenuOptionModel: Int, CaseIterable {
             case .profile: "person"
             case .manageConnections: "rectangle.connected.to.line.below"
             case .healthSummary: "heart.text.clipboard"
+            case .financial: "creditcard"
             case .logout: "arrow.right.square"
         }
     }
@@ -41,6 +44,7 @@ enum SideMenuOptionModel: Int, CaseIterable {
             case .profile: .profile
             case .manageConnections: .manageConnections
             case .healthSummary: .healthSummary
+            case .financial: .financial
             case .logout: .home
         }
     }

--- a/bwell-swift-ios/bwell-swift-ios/Utils/RootView.swift
+++ b/bwell-swift-ios/bwell-swift-ios/Utils/RootView.swift
@@ -33,6 +33,9 @@ struct RootView: View {
                         case .manageConnections:
                             ManageConnectionsView(showMenu: $showMenu)
                                 .navigationBarBackButtonHidden()
+                        case .financial:
+                            FinancialView(showMenu: $showMenu)
+                                .navigationBarBackButtonHidden()
                         case .searchConnections(let connection):
                             SearchConnectionsView(connection: connection)
                         case .connections:

--- a/bwell-swift-ios/bwell-swift-ios/Utils/Router.swift
+++ b/bwell-swift-ios/bwell-swift-ios/Utils/Router.swift
@@ -14,6 +14,7 @@ enum AppView: Hashable {
     case profile
     case healthSummary
     case manageConnections
+    case financial
 
     // Subviews of manageConnections
     case connections


### PR DESCRIPTION
## Summary
- Add Financial section demonstrating getCoverages and getExplanationOfBenefits
- Add Goals view demonstrating HealthDataManager.getGoals (EA-2153 new operation)
- Enable telemetry in SDK initialization
- Update README with all demonstrated features

## New screens
- Financial View (coverages + EOBs)
- Goals View (lifecycle status, achievement, categories)

## Test plan
- [ ] App builds in Xcode
- [ ] Financial section navigable from side menu
- [ ] Goals view accessible from Health Summary
- [ ] Telemetry enabled in SDK init