### PR TITLE
Updated default callback url for createVerificationUrl

### DIFF
--- a/bwell-swift-ios/bwell-swift-ios/Profile/ProfileViewModel.swift
+++ b/bwell-swift-ios/bwell-swift-ios/Profile/ProfileViewModel.swift
@@ -99,7 +99,7 @@ final class ProfileViewModel: ObservableObject {
     func createVerificationURL(sdk: BWellClient) async {
         do {
             let json = """
-            {"callbackURL":"bwellexample://verification-callback","includeAttributeMatchingCheck":false}
+            {"callbackURL":"bwell://ial2-callback","includeAttributeMatchingCheck":false}
             """
             let request = try JSONDecoder().decode(
                 BWell.CreateVerificationURLRequest.self,


### PR DESCRIPTION
`createVerificationUrl` has to have the callback URL allowlisted in Client Hub or else it fails. Updated the sample app to use our default callback URL that is configured for all new clients (until they give us their real callback URL).