### PR TITLE
fixing references so that the State's state updates correctly

### DIFF
--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/profile/ProfileFragment.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/profile/ProfileFragment.kt
@@ -141,13 +141,13 @@ class ProfileFragment : Fragment() {
         //create state Spinner
         val stateSpinner: Spinner = binding.includeEditProfile.stateSpinner
         val stateAdapter = ArrayAdapter.createFromResource(requireContext(), R.array.states, android.R.layout.simple_spinner_item)
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        stateAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         // Apply the adapter to the spinner
         stateSpinner.adapter = stateAdapter
         // Set the on item selected listener
         stateSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parentView: AdapterView<*>, selectedItemView: View?, position: Int, id: Long) {
-                selectedState = spinner.selectedItem.toString()
+                selectedState = stateSpinner.selectedItem.toString()
 
             }
             override fun onNothingSelected(p0: AdapterView<*>?) {


### PR DESCRIPTION
Fix: State field incorrectly sent as "male"/"female" on profile update (TIP-7300)
Re-submission of #179, which was closed due to a branch history issue.

Problem
When a user updated their profile in the Kotlin Android sample app, the state field in their address was being saved as either "male" or "female" instead of the selected state value. The incorrect value was going into the updateUserProfile GraphQL mutation body and persisting to FHIR.

Root cause
Two variable name errors in ProfileFragment.kt caused the state spinner to read from the gender spinner instead:

kotlin// Before (buggy)
adapter.setDropDownViewResource(...)        // should be stateAdapter
selectedState = spinner.selectedItem.toString()   // should be stateSpinner

kotlin// After (fixed)
stateAdapter.setDropDownViewResource(...)
selectedState = stateSpinner.selectedItem.toString()