### PR TITLE
PAY-2379: bump insurance-demo SDK dependency to released 1.18.0

### DIFF
--- a/bwell-kotlin-android/app/build.gradle.kts
+++ b/bwell-kotlin-android/app/build.gradle.kts
@@ -69,10 +69,7 @@ android {
 dependencies {
 
     // BWell SDK Usage
-    // TODO(PAY-2379): the insurance coverage-filter demo needs the SDK build that adds
-    // ExplanationOfBenefitRequest.coverage(); bump this to that released version once
-    // https://github.com/icanbwell/bwell-sdk/pull/899 is merged and published.
-    implementation("com.bwell:bwell-sdk-kotlin:1.17.0-20260724.191750-3")
+    implementation("com.bwell:bwell-sdk-kotlin:1.18.0")
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")

--- a/bwell-kotlin-android/settings.gradle.kts
+++ b/bwell-kotlin-android/settings.gradle.kts
@@ -15,9 +15,6 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://artifacts.icanbwell.com/repository/bwell-public/")
         }
-        maven {
-            url = uri("https://artifacts.icanbwell.com/repository/bwell-sdk-snapshot/")
-        }
     }
 }
 

--- a/bwell-kotlin-android/settings.gradle.kts
+++ b/bwell-kotlin-android/settings.gradle.kts
@@ -13,6 +13,9 @@ dependencyResolutionManagement {
         // BWell SDK Usage
         // mavenLocal() //uncomment after running `./gradlew publishToMavenLocal` in the SDK for testing
         maven {
+            url = uri("https://artifacts.icanbwell.com/repository/bwell-public/")
+        }
+        maven {
             url = uri("https://artifacts.icanbwell.com/repository/bwell-sdk-snapshot/")
         }
     }


### PR DESCRIPTION
- 1.18.0 includes ExplanationOfBenefitRequest.Builder.coverage() (bwell-sdk PR #899), so the coverage-filter demo added in #191 now builds against a real release instead of a snapshot build.
- Remove the internal TODO(PAY-2379) comment/PR link that shouldn't ship in the public sample app.
- Add the bwell-public release Maven repo to settings.gradle.kts (was only pointing at the snapshot repo, so no release version could resolve).