### PR TITLE
DCON-4878 bump bwell-kotlin-android toolchain (AGP 8.9.1, Kotlin 1.9.24, minSdk 29)

### DIFF
--- a/bwell-kotlin-android/app/build.gradle.kts
+++ b/bwell-kotlin-android/app/build.gradle.kts
@@ -12,11 +12,16 @@ configurations.all {
 
 android {
     namespace = "com.bwell.sampleapp"
-    compileSdk = 34
+    // 36 is required by the Health Sync on-device adapter's AndroidX Health
+    // Connect dependency (confirmed via its AAR metadata: minCompileSdk=36).
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.bwell.sampleapp"
-        minSdk = 26
+        // 29 is required by the Health Sync adapter AAR's own manifest
+        // (uses-sdk minSdkVersion=29) - this is an app-wide floor, not
+        // scoped to the Health Sync feature alone.
+        minSdk = 29
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
@@ -37,11 +42,14 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
+        // The Health Sync / adapter AARs ship Kotlin 1.9 metadata; without
+        // this the compiler refuses to read them.
+        freeCompilerArgs += "-Xskip-metadata-version-check"
     }
     buildFeatures {
         viewBinding = true
@@ -49,7 +57,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.14"
     }
     packaging {
         resources {
@@ -74,7 +82,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.activity:activity-compose:1.8.2")
-    implementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    implementation(platform("androidx.compose:compose-bom:2023.10.01"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -106,7 +114,7 @@ dependencies {
     testImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2023.10.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/bwell-kotlin-android/build.gradle.kts
+++ b/bwell-kotlin-android/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.10" apply false
+    id("com.android.application") version "8.9.1" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
     id("com.google.gms.google-services") version "4.4.0" apply false
 }

--- a/bwell-kotlin-android/gradle.properties
+++ b/bwell-kotlin-android/gradle.properties
@@ -6,7 +6,11 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+# Health Sync's on-device adapter pulls in an AndroidX library that requires
+# compileSdk 36; suppress the "unsupported compileSdk" warning until a
+# stable AGP release officially lists 36 as supported.
+android.suppressUnsupportedCompileSdk=36
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/bwell-kotlin-android/gradle/wrapper/gradle-wrapper.properties
+++ b/bwell-kotlin-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 24 13:37:11 EDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
Phase 1 of DCON-4877 (Health Sync Playground Migration & Toolchain Modernization). Bumps `bwell-kotlin-android`'s whole-app toolchain to the floor the upcoming Health Sync adapter requires, with zero feature code - isolated on purpose so any toolchain regression is bisectable independently of the SDK bump (next) and the Health Sync port (after that).

- AGP `8.7.3` -> `8.9.1`
- Kotlin `1.8.10` -> `1.9.24`
- Gradle `8.9` -> `8.11.1`
- `compileSdk` `34` -> `36`
- `minSdk` `26` -> `29` (**app-wide** - drops API 26-28 device support for the whole example app, not just Health Sync)
- `jvmTarget` `1.8` -> `17`
- Compose compiler ext `1.4.3` -> `1.5.14`, Compose BOM `2023.03.00` -> `2023.10.01`

## Why these specific floors
- The Health Sync adapter's `androidx.health.connect:connect-client` dependency requires `minCompileSdk=36` and `minAndroidGradlePluginVersion=8.9.1` (confirmed via its AAR metadata).
- The adapter AAR's own manifest requires `minSdkVersion=29`.
- `bwell-sdk-kotlin-healthsync`/`-healthsync-adapter-aggregator` ship Kotlin 1.9 metadata, unreadable by 1.8.10.

## Test plan
- [x] `./gradlew clean assembleDebug` - green (the repo's actual CI gate, `generate_apk.yml`)
- [x] `./gradlew test` / `./gradlew lint` - both have pre-existing failures (a stale `MyActivityTest` Espresso assertion, an `OnClick` handler lint error). Confirmed via `git stash` that both reproduce identically on unmodified `main` - not caused by this change.
- [ ] CI (`generate_apk.yml`) green on this PR

Tracked under Epic DCON-4877, ticket DCON-4878.