### PR TITLE
DCON-4878 bump bwell-sdk-kotlin to 1.20.0

### DIFF
--- a/bwell-kotlin-android/app/build.gradle.kts
+++ b/bwell-kotlin-android/app/build.gradle.kts
@@ -77,7 +77,7 @@ android {
 dependencies {
 
     // BWell SDK Usage
-    implementation("com.bwell:bwell-sdk-kotlin:1.18.0")
+    implementation("com.bwell:bwell-sdk-kotlin:1.20.0")
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")


### PR DESCRIPTION
## Summary
PR 2 of 2 for DCON-4878 (PR 1 = #203, already merged - the toolchain bump). Core SDK version bump only, no feature code - isolated on purpose so any API-drift regression is bisectable independently of the toolchain bump and the upcoming Health Sync port.

- `com.bwell:bwell-sdk-kotlin` `1.18.0` -> `1.20.0`

## API drift check
Two minor versions land on all 9 existing feature domains at once (DataConnections, HealthSummary, HealthJourney, Insurance, Labs, Medicines, Profile, Home, HealthMatchConsent). Checked via full compile rather than manual review, since the compiler catches renamed builders/changed `BWellResult` shapes reliably:

- `./gradlew clean assembleDebug` - **BUILD SUCCESSFUL**, zero errors, only pre-existing lint warnings unrelated to the SDK (unused params, unnecessary safe calls, etc.)
- No API drift found across any of the 9 domains.

## Test plan
- [x] `./gradlew clean assembleDebug` - green
- [x] `./gradlew test` - same single pre-existing `MyActivityTest` Espresso failure PR #203 already confirmed unrelated (reproduces identically on unmodified `main`) - no new failures
- [x] Installed and launched the built APK on a real emulator (API 36) - app launches, login screen renders correctly (Client Key / OAuth Credentials fields, Login / Launch Embeddable buttons), no crash
- [ ] CI (`generate_apk.yml`) green on this PR

Tracked under Epic DCON-4877, ticket DCON-4878.