### PR TITLE
security: stop logging credentials to device logs (Kotlin + React Native)

### DIFF
--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/login/LoginFragment.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/login/LoginFragment.kt
@@ -385,9 +385,10 @@ class LoginFragment : Fragment() {
                 .build()
 
             BWellSdk.initialize(config = config)
+            // NOTE: never log `credentials.token` — it is a live bearer credential
+            // and this app ships with isMinifyEnabled = false and no log stripping.
             val credentials =
                 Credentials.OAuthCredentials(oAuthCredentials)
-            Log.d(TAG, credentials.token)
 
             BWellSdk.authenticate(credentials)
 

--- a/bwell-react-native/components/client-key.tsx
+++ b/bwell-react-native/components/client-key.tsx
@@ -39,7 +39,9 @@ export function ClientKeyProvider({ children }: PropsWithChildren) {
       let hasKey = false;
       let stateKey = '';
 
-      console.info('storage key', key)
+      // Never log the key itself — this is a credential and console output
+      // is not stripped from React Native release builds by default.
+      console.debug('client key from storage:', key === null ? 'none' : 'present')
 
       if (key !== null) {
         stateKey = key;
@@ -66,7 +68,7 @@ export function ClientKeyProvider({ children }: PropsWithChildren) {
 
   const setKey = async (key: string) => {
     try {
-      console.log('setting key')
+      console.debug('setting client key')
 
       await AsyncStorage.setItem(CLIENT_KEY_STORAGE_KEY, key)
 


### PR DESCRIPTION
## What

Removes two log statements that write live credentials to device logs.

**`bwell-kotlin-android/.../login/LoginFragment.kt`**

```diff
             val credentials =
                 Credentials.OAuthCredentials(oAuthCredentials)
-            Log.d(TAG, credentials.token)
 
             BWellSdk.authenticate(credentials)
```

**`bwell-react-native/components/client-key.tsx`**

```diff
-      console.info('storage key', key)
+      console.debug('client key from storage:', key === null ? 'none' : 'present')
```

## Why

Both write a live credential in cleartext, on a normal code path, in **release** builds.

**Kotlin** — `Log.d(TAG, credentials.token)` emits the full OAuth bearer token to logcat immediately before `BWellSdk.authenticate()`. It is not guarded by `BuildConfig.DEBUG`. The release build type sets `isMinifyEnabled = false` and `proguard-rules.pro` contains no log-stripping rule, so the statement is present in release APKs — including the `app-debug.apk` that `release.yml` attaches to every GitHub release.

**React Native** — `console.info('storage key', key)` prints the raw client key on every app launch. React Native does not strip `console.*` in release builds by default, and this project has no `babel.config.js` and no `babel-plugin-transform-remove-console`.

This is a **public sample-app repo**. External developers copy these patterns into production integrations, which is what turns a logging slip into a distributed one.

## Scope

Deliberately minimal — one bug class, two files, no refactoring. Per the method's "one finding, one PR, one ticket" rule.

**Not** addressed here, tracked separately:

- `logLevel(LogLevel.DEBUG)` / `logLevel: .verbose` hardcoded in all build configs → PR 2
- PHI written to logs in Kotlin and Swift (`Binary` resources, `MedicationRequest`, vital-sign values, OAuth redirect URLs, per-keystroke search terms)
- Credential storage posture differing across all four sample apps

## Verification

Both source locations were re-fetched from `refs/heads/main` and confirmed verbatim before editing.

No behavioral change. `android.util.Log` remains imported and used elsewhere in `LoginFragment.kt`, so no unused-import warning is introduced. The React Native replacement keeps a debug line for the same diagnostic purpose without emitting the secret.

## Reference

Rule **CRED-01** in the behavior specification: *"No auth token, client key, or password appears in any log sink in any build configuration."* Status was KNOWN GAP; this PR is the first step toward ENFORCED.

- [Behavior specification](https://icanbwell.atlassian.net/wiki/spaces/DX/pages/6617858072)
- [Applying the FHIR Server Method to bwell-sdk-example](https://icanbwell.atlassian.net/wiki/spaces/DX/pages/6618710017)

## Note on the method's test requirement

The method this came from requires every finding to ship with a failing test. **This PR does not have one**, because the repo currently cannot run tests: the Swift suite is not in `project.pbxproj`, Kotlin has no mocking framework, and React Native has no test runner. Fixing that is the next tranche of work. Flagging it explicitly rather than quietly skipping the rule.