### PR TITLE
security: gate SDK log level on build configuration (Kotlin + Swift)

### DIFF
--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/login/LoginFragment.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/login/LoginFragment.kt
@@ -33,6 +33,7 @@ import com.bwell.healthdata.requests.fhir.FhirRequest
 import com.bwell.healthdata.requests.fhir.GetFhirSearchDate
 import com.bwell.healthdata.requests.fhir.enums.ResourceType
 import com.bwell.sampleapp.BWellSampleApplication
+import com.bwell.sampleapp.BuildConfig
 import com.bwell.sampleapp.R
 import com.bwell.sampleapp.singletons.BWellSdk
 import com.bwell.user.requests.consents.ConsentCreateRequest
@@ -74,6 +75,16 @@ class LoginFragment : Fragment() {
     private val bootstrapApiURL = "https://api-gateway.client-sandbox.icanbwell.com/identity" // NOTE: Defaults to bwell `client-sandbox` environment
     private var clientKey: String? = null
     private var oAuthCredentials: String? = null
+
+    /**
+     * SDK log level, chosen by build type.
+     *
+     * DEBUG must never reach a release build: this module sets
+     * `isMinifyEnabled = false` and ships no ProGuard log-stripping rule, so
+     * anything the SDK logs at DEBUG is present in a release APK.
+     */
+    private val sdkLogLevel: LogLevel
+        get() = if (BuildConfig.DEBUG) LogLevel.DEBUG else LogLevel.ERROR
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -373,7 +384,7 @@ class LoginFragment : Fragment() {
 
             val config: BWellConfig = BWellConfig.Builder()
                 .clientKey(clientKey)
-                .logLevel(LogLevel.DEBUG)
+                .logLevel(sdkLogLevel)
                 .timeout(20000)
                 .retryPolicy(
                     RetryPolicy.Builder()

--- a/bwell-swift-ios/bwell-swift-ios/Core/SDKManager.swift
+++ b/bwell-swift-ios/bwell-swift-ios/Core/SDKManager.swift
@@ -14,6 +14,19 @@ final class SDKManager: ObservableObject {
     @Published private(set) var state: SDKState = .uninitialized
     private(set) var sdk: BWellClient?
 
+    /// SDK log level, chosen by build configuration.
+    ///
+    /// `.verbose` must never reach a release build: NSLog output persists in the
+    /// unified system log and is collected by sysdiagnose, so verbose SDK logging
+    /// puts request/response detail on the device indefinitely.
+    private static var configuredLogLevel: BWell.LogLevel {
+        #if DEBUG
+        return .verbose
+        #else
+        return .error
+        #endif
+    }
+
     func initialize(_ clientKey: String) async throws {
         guard sdk == nil else {
             state = .initialized
@@ -26,7 +39,7 @@ final class SDKManager: ObservableObject {
             let keychainAdapter = KeychainTokenStorageAdapter()
             let config = BWell.SDKConfig(
                 clientKey: clientKey.trimmingCharacters(in: .whitespacesAndNewlines),
-                logLevel: .verbose,
+                logLevel: Self.configuredLogLevel,
                 tokenStorage: keychainAdapter
             )
             let sdkInstance = try BWellClient(config: config)


### PR DESCRIPTION
> **Stacked on [#208](https://github.com/icanbwell/bwell-sdk-example/pull/208).** Both PRs touch `LoginFragment.kt`, so this targets `security/strip-credential-logging` rather than `main`. GitHub will retarget it to `main` automatically when #208 merges. **Review and merge #208 first.**

## What

Both SDKs had their most verbose log level hardcoded for every build configuration.

**`bwell-kotlin-android/.../login/LoginFragment.kt`**

```diff
+    private val sdkLogLevel: LogLevel
+        get() = if (BuildConfig.DEBUG) LogLevel.DEBUG else LogLevel.ERROR
...
             val config: BWellConfig = BWellConfig.Builder()
                 .clientKey(clientKey)
-                .logLevel(LogLevel.DEBUG)
+                .logLevel(sdkLogLevel)
```

**`bwell-swift-ios/.../Core/SDKManager.swift`**

```diff
+    private static var configuredLogLevel: BWell.LogLevel {
+        #if DEBUG
+        return .verbose
+        #else
+        return .error
+        #endif
+    }
...
             let config = BWell.SDKConfig(
                 clientKey: clientKey.trimmingCharacters(in: .whitespacesAndNewlines),
-                logLevel: .verbose,
+                logLevel: Self.configuredLogLevel,
                 tokenStorage: keychainAdapter
             )
```

## Why

Neither varied by build configuration, so whatever each SDK emits at its most verbose level — request and response detail, token lifecycle — reached production logs.

**Kotlin.** The release build type sets `isMinifyEnabled = false` and `proguard-rules.pro` contains no log-stripping rule, so SDK DEBUG output is present in release APKs.

**Swift.** The SDK logs via `NSLog`, which writes to the unified system log. That persists on device and is collected by sysdiagnose, so `.verbose` in a release build leaves SDK detail on the device indefinitely.

## Enum values verified

Both replacement values were confirmed against `icanbwell/bwell-sdk` rather than assumed:

- `LogLevel.ERROR` — used in `bwell-sdk-kotlin/bwell-core/.../logger/BWellLogger.kt`
- `BWell.LogLevel.error` — used in `bwell-sdk-swift/Tests/BwellSDKTests/TestHelpers/TestSDKConfig.swift`

## Same-shape search (review.md rule 14)

Searched the org for every `logLevel` assignment. Three other hits, none needing a change here:

| Location | Finding |
|---|---|
| `bwell-kotlin-android/.../MainActivity.kt` | Imports `LogLevel`, `BWellConfig`, `RetryPolicy` and `Credentials` and **uses none of them**. Dead imports from removed code — separate cleanup, no log level is set |
| `bwell-swift-ios/.../SDKManager/BWellSDKManager.swift` | Also hardcodes `logLevel: .verbose`, but this file is **not referenced in `project.pbxproj`** — it is an orphaned duplicate of `Core/SDKManager.swift` with its own divergent `SDKError` and a broken `SDKState` equality (`case (.failed, .failed): return false`). Deliberately not patched: fixing dead code hides it. Tracked under the "inconsistent twins" cleanup |
| `bwell-sdk-kotlin/.../SdkConfig.kt` | SDK-side default of `LogLevel.DEBUG`. Upstream repo, out of scope, but worth a conversation with the SDK team — a sample app shouldn't have to opt out of verbose logging |

## Verification

No behavioral change in debug builds. `LogLevel` remains imported and used in both files.

**Not compile-verified** — this repo has no CI that builds the Swift app, and the Android job only runs `assembleDebug`. Please build both locally before approving. That CI gap is itself tracked as CI-01.

## Reference

Rule **CRED-02**: *"SDK log level is not DEBUG/verbose in a release build."* Status KNOWN GAP → this closes it for both apps.

- [Behavior specification](https://icanbwell.atlassian.net/wiki/spaces/DX/pages/6617858072)
- [Applying the FHIR Server Method to bwell-sdk-example](https://icanbwell.atlassian.net/wiki/spaces/DX/pages/6618710017)

## No failing test attached

Same caveat as #208. The repo cannot currently run tests — Swift suite not in `project.pbxproj`, Kotlin has no mocking framework, RN has no runner. Flagging rather than skipping the method's rule silently.