### PR TITLE
test(ts-react): bootstrap Vitest + logic-layer unit tests (unit-test-master)

### DIFF
--- a/bwell-typescript-react/package.json
+++ b/bwell-typescript-react/package.json
@@ -9,6 +9,8 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "e2e": "npx playwright test --browser=chromium --reporter=html --workers=3 && npx playwright show-report --host 127.0.0.1"
   },
   "dependencies": {
@@ -41,6 +43,7 @@
     "playwright": "^1.56.1",
     "toml": "^3.0.0",
     "typescript": "^5.4.5",
-    "vite": "^7.1.11"
+    "vite": "^7.1.11",
+    "vitest": "^2.1.9"
   }
 }

--- a/bwell-typescript-react/src/sdk/getUserProfile.test.ts
+++ b/bwell-typescript-react/src/sdk/getUserProfile.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getSdk } from "@/sdk/bWellSdk";
+import { getUserProfile } from "./getUserProfile";
+
+vi.mock("@/sdk/bWellSdk", () => ({ getSdk: vi.fn() }));
+
+const mockGetSdk = vi.mocked(getSdk);
+
+const withProfile = (data: unknown): void => {
+  mockGetSdk.mockReturnValue({
+    user: { getProfile: vi.fn().mockResolvedValue({ data }) },
+  } as unknown as ReturnType<typeof getSdk>);
+};
+
+beforeEach(() => {
+  mockGetSdk.mockReset();
+});
+
+describe("getUserProfile", () => {
+  test("returns fully-defaulted fields when the SDK is not initialized", async () => {
+    mockGetSdk.mockReturnValue(undefined);
+
+    const profile = await getUserProfile();
+
+    expect(profile.id).toBeNull();
+    expect(profile.firstName).toBe("");
+    expect(profile.lastName).toBe("");
+    expect(profile.email).toBe("");
+    expect(profile.city).toBe("");
+    expect(profile.addressStreet).toBe("");
+  });
+
+  test("flattens FHIR name, address, and telecom into scalar fields", async () => {
+    withProfile({
+      id: "u1",
+      gender: "female",
+      birthDate: "1990-01-01",
+      language: "en",
+      name: [{ given: ["Ada", "B"], family: "Lovelace" }],
+      address: [{ line: ["1 Main St"], city: "Metropolis", state: "NY", postalCode: "10001" }],
+      telecom: [
+        { system: "phone", use: "home", value: "111" },
+        { system: "phone", use: "mobile", value: "222" },
+        { system: "phone", use: "work", value: "333" },
+        { system: "email", value: "ada@example.com" },
+      ],
+    });
+
+    const profile = await getUserProfile();
+
+    expect(profile.firstName).toBe("Ada");
+    expect(profile.lastName).toBe("Lovelace");
+    expect(profile.addressStreet).toBe("1 Main St");
+    expect(profile.city).toBe("Metropolis");
+    expect(profile.state).toBe("NY");
+    expect(profile.postalCode).toBe("10001");
+    expect(profile.homePhone).toBe("111");
+    expect(profile.mobilePhone).toBe("222");
+    expect(profile.workPhone).toBe("333");
+    expect(profile.email).toBe("ada@example.com");
+    expect(profile.id).toBe("u1");
+    expect(profile.gender).toBe("female");
+  });
+
+  test("removes the nested FHIR parent fields it flattened", async () => {
+    withProfile({
+      name: [{ given: ["Grace"], family: "Hopper" }],
+      address: [{ line: ["x"], city: "c" }],
+      telecom: [{ system: "email", value: "g@example.com" }],
+    });
+
+    const profile = await getUserProfile() as Record<string, unknown>;
+
+    expect(profile.name).toBeUndefined();
+    expect(profile.address).toBeUndefined();
+    expect(profile.telecom).toBeUndefined();
+  });
+
+  test("selects the correct telecom entry by system and use", async () => {
+    withProfile({
+      telecom: [
+        { system: "phone", use: "mobile", value: "MOBILE" },
+        { system: "phone", use: "home", value: "HOME" },
+        { system: "email", value: "E@example.com" },
+      ],
+    });
+
+    const profile = await getUserProfile();
+
+    expect(profile.mobilePhone).toBe("MOBILE");
+    expect(profile.homePhone).toBe("HOME");
+    expect(profile.workPhone).toBe("");
+    expect(profile.email).toBe("E@example.com");
+  });
+
+  // Parameter sensitivity: a different profile input yields the correspondingly different output.
+  test("output reflects the specific profile returned by the SDK", async () => {
+    withProfile({ name: [{ given: ["Grace"], family: "Hopper" }] });
+
+    const profile = await getUserProfile();
+
+    expect(profile.firstName).toBe("Grace");
+    expect(profile.lastName).toBe("Hopper");
+    expect(profile.email).toBe("");
+  });
+
+  test("falls back to empty strings when name/address/telecom are absent", async () => {
+    withProfile({ id: "only-id" });
+
+    const profile = await getUserProfile();
+
+    expect(profile.id).toBe("only-id");
+    expect(profile.firstName).toBe("");
+    expect(profile.addressStreet).toBe("");
+    expect(profile.homePhone).toBe("");
+  });
+});

--- a/bwell-typescript-react/src/store/connectionSlice.test.ts
+++ b/bwell-typescript-react/src/store/connectionSlice.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { connectionSlice, getMemberConnections } from "./connectionSlice";
+
+const reducer = connectionSlice.reducer;
+
+describe("connectionSlice", () => {
+  test("initial state has no connections and no error", () => {
+    expect(reducer(undefined, { type: "@@INIT" })).toEqual({
+      memberConnections: null,
+      dataSource: null,
+      loading: false,
+      error: null,
+    });
+  });
+
+  test("pending clears data and sets loading", () => {
+    const state = reducer(
+      { memberConnections: [{ id: "old" }] as any, dataSource: null, loading: false, error: "e" },
+      getMemberConnections.pending("rid", undefined),
+    );
+    expect(state.loading).toBe(true);
+    expect(state.memberConnections).toBeNull();
+    expect(state.error).toBeNull();
+  });
+
+  test("fulfilled stores the returned connections and stops loading", () => {
+    const state = reducer(
+      { memberConnections: null, dataSource: null, loading: true, error: null },
+      getMemberConnections.fulfilled([{ id: "a" }] as any, "rid", undefined),
+    );
+    expect(state.memberConnections).toEqual([{ id: "a" }]);
+    expect(state.loading).toBe(false);
+  });
+
+  test("rejected with 'Uninitialized' keeps the slice loading", () => {
+    const state = reducer(
+      { memberConnections: null, dataSource: null, loading: false, error: null },
+      getMemberConnections.rejected(new Error("Uninitialized"), "rid", undefined),
+    );
+    expect(state.loading).toBe(true);
+  });
+
+  test("rejected with another error records the message", () => {
+    const state = reducer(
+      { memberConnections: null, dataSource: null, loading: true, error: null },
+      getMemberConnections.rejected(new Error("network down"), "rid", undefined),
+    );
+    expect(state.error).toBe("network down");
+  });
+
+  // BUG (see .qa/bugs-found.md #B1): same defect as makeHealthDataSlice — the fulfilled handler
+  // reads `action.payload.error.message` but then unconditionally overwrites `state.error` with "".
+  // A fulfilled response that carries a business error therefore surfaces NO error. This asserts
+  // the CORRECT behavior and is expected to fail until fixed.
+  test.fails(
+    "BUG: a fulfilled-with-error payload should surface the error, but it is overwritten with ''",
+    () => {
+      const state = reducer(
+        { memberConnections: null, dataSource: null, loading: true, error: null },
+        getMemberConnections.fulfilled({ error: { message: "eek" } } as any, "rid", undefined),
+      );
+      expect(state.error).toBe("eek");
+    },
+  );
+});

--- a/bwell-typescript-react/src/store/healthData/makeHealthDataSlice.test.ts
+++ b/bwell-typescript-react/src/store/healthData/makeHealthDataSlice.test.ts
@@ -1,0 +1,104 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { describe, expect, test } from "vitest";
+import { makeHealthDataSlice } from "./makeHealthDataSlice";
+
+const makeGetter = () => createAsyncThunk<any, void>("test/get", async () => ({}));
+
+const build = () => {
+  const getter = makeGetter();
+  const slice = makeHealthDataSlice("test", getter);
+  return { getter, slice, reducer: slice.reducer };
+};
+
+describe("makeHealthDataSlice", () => {
+  test("initial state has no data, is not loading, and has no error", () => {
+    const { reducer } = build();
+
+    expect(reducer(undefined, { type: "@@INIT" })).toEqual({
+      healthData: null,
+      loading: false,
+      error: null,
+    });
+  });
+
+  test("pending clears prior data/error and sets loading", () => {
+    const { getter, reducer } = build();
+
+    const state = reducer(
+      { healthData: [{ a: 1 }] as any, loading: false, error: "old" },
+      getter.pending("rid", undefined),
+    );
+
+    expect(state.loading).toBe(true);
+    expect(state.error).toBeNull();
+    expect(state.healthData).toBeNull();
+  });
+
+  test("fulfilled stores the payload as healthData and stops loading", () => {
+    const { getter, reducer } = build();
+    const payload = { entry: [{ id: "x" }] };
+
+    const state = reducer(
+      { healthData: null, loading: true, error: null },
+      getter.fulfilled(payload as any, "rid", undefined),
+    );
+
+    expect(state.healthData).toEqual(payload);
+    expect(state.loading).toBe(false);
+  });
+
+  test("resetState returns the slice to its initial state", () => {
+    const { slice } = build();
+
+    const state = slice.reducer(
+      { healthData: [{ a: 1 }] as any, loading: true, error: "e" },
+      slice.actions.resetState(),
+    );
+
+    expect(state).toEqual({ healthData: null, loading: false, error: null });
+  });
+
+  test("rejected with 'Uninitialized' keeps the slice loading (waiting for init)", () => {
+    const { getter, reducer } = build();
+
+    const state = reducer(
+      { healthData: null, loading: false, error: null },
+      getter.rejected(new Error("Uninitialized"), "rid", undefined),
+    );
+
+    expect(state.loading).toBe(true);
+  });
+
+  test("rejected with any other error records the error message", () => {
+    const { getter, reducer } = build();
+
+    const state = reducer(
+      { healthData: null, loading: true, error: null },
+      getter.rejected(new Error("network down"), "rid", undefined),
+    );
+
+    expect(state.error).toBe("network down");
+  });
+
+  // BUG (see .qa/bugs-found.md #B1): the fulfilled handler sets `state.error` from
+  // `action.payload.error.message`, then UNCONDITIONALLY overwrites it with "". A fulfilled
+  // action that carries a business error therefore surfaces NO error to the UI. This asserts
+  // the CORRECT behavior (error should be preserved) and is expected to fail until fixed.
+  test.fails(
+    "BUG: a fulfilled-with-error payload should surface the error, but it is overwritten with ''",
+    () => {
+      const { getter, reducer } = build();
+
+      const state = reducer(
+        { healthData: null, loading: true, error: null },
+        getter.fulfilled(
+          { error: { message: "boom" } } as any,
+          "rid",
+          undefined,
+        ),
+      );
+
+      expect(state.error).toBe("boom");
+    },
+  );
+});

--- a/bwell-typescript-react/src/store/requestInfoSlice.test.ts
+++ b/bwell-typescript-react/src/store/requestInfoSlice.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import { INITIAL_REQUEST, requestInfoSlice } from "./requestInfoSlice";
+
+const reducer = requestInfoSlice.reducer;
+const actions = requestInfoSlice.actions;
+const empty = () => reducer(undefined, { type: "@@INIT" });
+
+describe("requestInfoSlice", () => {
+  test("lazily initializes a request entry for a new selector on setPage", () => {
+    const state = reducer(empty(), actions.setPage({ selector: "labs", page: 3 }));
+
+    expect(state.labs.page).toBe(3);
+    expect(state.labs.pageSize).toBe(INITIAL_REQUEST.pageSize);
+  });
+
+  test("setPageSize updates pageSize while preserving page", () => {
+    let state = reducer(empty(), actions.setPage({ selector: "labs", page: 3 }));
+    state = reducer(state, actions.setPageSize({ selector: "labs", pageSize: 25 }));
+
+    expect(state.labs.pageSize).toBe(25);
+    expect(state.labs.page).toBe(3);
+  });
+
+  test("tracks selectors independently", () => {
+    let state = reducer(empty(), actions.setPage({ selector: "labs", page: 2 }));
+    state = reducer(state, actions.setPage({ selector: "conditions", page: 5 }));
+
+    expect(state.labs.page).toBe(2);
+    expect(state.conditions.page).toBe(5);
+  });
+
+  test("setGroupCode uses the encounters-specific shape for the 'encounters' selector", () => {
+    const state = reducer(
+      empty(),
+      actions.setGroupCode({ selector: "encounters", groupCode: { code: "E1", system: "sys" } as any }),
+    );
+
+    expect(state.encounters.groupCode).toEqual({ value: { value: "E1", system: "sys" } });
+  });
+
+  test("setGroupCode uses the default (code/value) shape for other selectors", () => {
+    const state = reducer(
+      empty(),
+      actions.setGroupCode({ selector: "labs", groupCode: { code: "C1", value: "V1" } as any }),
+    );
+
+    expect(state.labs.groupCode).toEqual({ value: { code: "C1", value: "V1" } });
+  });
+
+  test("clearRequestInfo resets page, pageSize, and groupCode to defaults", () => {
+    let state = reducer(empty(), actions.setPage({ selector: "labs", page: 7 }));
+    state = reducer(state, actions.setPageSize({ selector: "labs", pageSize: 50 }));
+    state = reducer(state, actions.setGroupCode({ selector: "labs", groupCode: { code: "C", value: "V" } as any }));
+
+    state = reducer(state, actions.clearRequestInfo("labs"));
+
+    expect(state.labs.page).toBe(INITIAL_REQUEST.page);
+    expect(state.labs.pageSize).toBe(INITIAL_REQUEST.pageSize);
+    expect(state.labs.groupCode).toBeUndefined();
+  });
+
+  test("clearGroupCode removes only the group code", () => {
+    let state = reducer(
+      empty(),
+      actions.setGroupCode({ selector: "labs", groupCode: { code: "C", value: "V" } as any }),
+    );
+    state = reducer(state, actions.setPage({ selector: "labs", page: 4 }));
+
+    state = reducer(state, actions.clearGroupCode("labs"));
+
+    expect(state.labs.groupCode).toBeUndefined();
+    expect(state.labs.page).toBe(4);
+  });
+});

--- a/bwell-typescript-react/src/store/toggleSlice.test.ts
+++ b/bwell-typescript-react/src/store/toggleSlice.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import toggleReducer, { selectToggle, toggleValue } from "./toggleSlice";
+
+describe("toggleSlice", () => {
+  test("selectToggle defaults to true for a locator that was never toggled", () => {
+    const state = toggleReducer(undefined, { type: "@@INIT" });
+
+    expect(selectToggle({ toggle: state } as any, "never-seen")).toBe(true);
+  });
+
+  // The reducer initializes an unseen locator to `true`, then immediately applies `!value`,
+  // so the FIRST toggle of an unseen locator lands on `false` (turning the default-on view off).
+  test("first toggle of an unseen locator sets it to false", () => {
+    const state = toggleReducer(undefined, toggleValue("panel"));
+
+    expect(state.panel).toBe(false);
+  });
+
+  test("a second toggle flips it back to true", () => {
+    let state = toggleReducer(undefined, toggleValue("panel"));
+    state = toggleReducer(state, toggleValue("panel"));
+
+    expect(state.panel).toBe(true);
+  });
+
+  test("toggles distinct locators independently", () => {
+    let state = toggleReducer(undefined, toggleValue("a"));
+    state = toggleReducer(state, toggleValue("b"));
+    state = toggleReducer(state, toggleValue("b"));
+
+    expect(state.a).toBe(false);
+    expect(state.b).toBe(true);
+  });
+
+  test("selectToggle reflects the stored value once a locator has been toggled", () => {
+    const state = toggleReducer(undefined, toggleValue("x"));
+
+    expect(selectToggle({ toggle: state } as any, "x")).toBe(false);
+  });
+});

--- a/bwell-typescript-react/src/store/userSlice.test.ts
+++ b/bwell-typescript-react/src/store/userSlice.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import { authenticate, initialize, userSlice } from "./userSlice";
+
+const reducer = userSlice.reducer;
+const initial = reducer(undefined, { type: "@@INIT" });
+
+describe("userSlice", () => {
+  test("initial state is logged out, uninitialized, and not loading", () => {
+    expect(initial.isLoggedIn).toBe(false);
+    expect(initial.isInitialized).toBe(false);
+    expect(initial.loading).toBe(false);
+    expect(initial.error).toBeNull();
+  });
+
+  test("resetState clears session flags and marks the store rehydrated", () => {
+    const state = reducer(
+      { ...initial, isInitialized: true, isLoggedIn: true, clientKey: "k", oauthCreds: "c" },
+      userSlice.actions.resetState(),
+    );
+
+    expect(state.isInitialized).toBe(false);
+    expect(state.isLoggedIn).toBe(false);
+    expect(state.isRehydrated).toBe(true);
+    expect(state.clientKey).toBeUndefined();
+    expect(state.oauthCreds).toBeUndefined();
+  });
+
+  describe("authenticate thunk", () => {
+    test("pending sets loading and clears the logged-in flag", () => {
+      const state = reducer(initial, authenticate.pending("rid", {}));
+      expect(state.loading).toBe(true);
+      expect(state.isLoggedIn).toBe(false);
+    });
+
+    test("fulfilled stores the credentials and marks logged in", () => {
+      const state = reducer(initial, authenticate.fulfilled("creds-123", "rid", {}));
+      expect(state.oauthCreds).toBe("creds-123");
+      expect(state.isLoggedIn).toBe(true);
+      expect(state.loading).toBe(false);
+    });
+
+    test("rejected records the reject payload and stays logged out", () => {
+      const state = reducer(
+        { ...initial, loading: true },
+        authenticate.rejected(new Error("boom"), "rid", {}, "bad creds"),
+      );
+      expect(state.error).toBe("bad creds");
+      expect(state.isLoggedIn).toBe(false);
+      expect(state.loading).toBe(false);
+    });
+
+    test("rejected falls back to a default message when no payload is provided", () => {
+      const state = reducer(initial, authenticate.rejected(new Error("boom"), "rid", {}));
+      expect(state.error).toBe("Error while authenticating");
+    });
+  });
+
+  describe("initialize thunk", () => {
+    test("fulfilled stores the client key and marks initialized", () => {
+      const state = reducer(
+        initial,
+        initialize.fulfilled("client-key", "rid", { clientKey: "client-key" }),
+      );
+      expect(state.clientKey).toBe("client-key");
+      expect(state.isInitialized).toBe(true);
+      expect(state.loading).toBe(false);
+    });
+
+    test("rejected clears credentials and marks the SDK uninitialized", () => {
+      const state = reducer(
+        { ...initial, clientKey: "k", oauthCreds: "c", isInitialized: true, isLoggedIn: true },
+        initialize.rejected(new Error("boom"), "rid", { clientKey: "k" }, "init failed"),
+      );
+      expect(state.isInitialized).toBe(false);
+      expect(state.error).toBe("init failed");
+      expect(state.clientKey).toBeUndefined();
+      expect(state.oauthCreds).toBeUndefined();
+    });
+  });
+});

--- a/bwell-typescript-react/vitest.config.ts
+++ b/bwell-typescript-react/vitest.config.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+// Unit-test config for the sample app's logic layer (Redux slices + SDK wrappers).
+// Mirrors the "@" -> ./src alias from vite.config.ts. Node environment (no DOM) is
+// sufficient because this suite targets logic only, not React components.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Bootstraps **Vitest** for the `bwell-typescript-react` sample app and adds **39 unit tests across 6 files** covering the logic layer — Redux Toolkit slices/thunks and the `src/sdk/*` wrappers. UI components were intentionally out of scope for this pass.

- `vitest.config.ts` (node env, `@`→`src` alias); `test` / `test:watch` scripts; `vitest` devDep.

| File | Tests | Focus |
|---|---|---|
| `store/healthData/makeHealthDataSlice` | 7 | factory reducer: pending/fulfilled/rejected/reset |
| `store/userSlice` | 8 | authenticate & initialize state transitions |
| `store/connectionSlice` | 6 | member-connections reducer |
| `sdk/getUserProfile` | 6 | FHIR name/address/telecom flattening + defaults |
| `store/requestInfoSlice` | 7 | per-selector paging + group-code shaping |
| `store/toggleSlice` | 5 | toggle reducer + selector |

The 20 `store/healthData/*Slice.ts` files are thin wrappers over `makeHealthDataSlice` and are covered structurally by its tests.

## Verification note

Vitest could not be installed in the dev sandbox (pre-existing corrupted local `node_modules` — `npm i` crashes in arborist dedupe on `@swc/core`, `yarn` on corrupted cache tarballs). Each test's **logic was executed and verified via Node 24's native TypeScript runner** with an `@`→`src` resolve hook. In a clean environment: `npm i && npm test`.

## Bug surfaced (documented via `test.fails`)

`makeHealthDataSlice` and `connectionSlice` both have a `.fulfilled` handler that reads `payload.error.message` into `state.error`, then **unconditionally overwrites `state.error` with `""`** — so a business error delivered on a fulfilled action is silently swallowed (UI shows an empty view, no error). The two `test.fails` cases assert the correct behavior and will start passing once the handler is fixed (move the reset into the `else` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)