### PR TITLE
DCON-4618 port Health Sync Playground+Dashboard to Kotlin/Compose

### DIFF
--- a/bwell-kotlin-android/.gitignore
+++ b/bwell-kotlin-android/.gitignore
@@ -8,4 +8,12 @@
 /captures
 .externalNativeBuild
 .cxx
+
+# Health Sync on-device adapter local test overlay - see the two
+# .example templates at the repo root. Lets a developer plug in the
+# published adapter + vendor credentials locally, without ever committing
+# a vendor coordinate, a gated repo URL, or a vendor binary.
+/healthsync-local.settings.gradle.kts
+/healthsync-local.app.gradle.kts
+app/src/healthSyncLocal/
 local.properties

--- a/bwell-kotlin-android/README.md
+++ b/bwell-kotlin-android/README.md
@@ -141,6 +141,40 @@ import com.bwell.sampleapp.singletons.BWellSdk
 val helloStr = BWellSdk.hello()
 ```
 
+## Optional: Health Sync On-Device Adapter (Local Testing Only)
+
+The Health Sync feature (drawer item "Health Sync") works out of the box using
+only `com.bwell:bwell-sdk-kotlin-healthsync` - the vendor-neutral module. No
+on-device adapter, vendor dependency, or gated Maven repository is declared
+anywhere in this repo, so a fresh clone always builds without credentials.
+With no adapter configured, Health Sync shows the raw API Playground, with
+the 5 endpoints that need an on-device session ("Blocked").
+
+To test against a real on-device adapter (e.g. to record a demo), plug it in
+**locally** without touching any committed file:
+
+1. Copy the two templates and fill in your own JFrog credentials:
+   ```bash
+   cp healthsync-local.settings.gradle.kts.example healthsync-local.settings.gradle.kts
+   cp healthsync-local.app.gradle.kts.example healthsync-local.app.gradle.kts
+   ```
+2. Copy the neutral bridge and replace its no-op bodies with real calls into
+   the adapter (see `bwell-sdk-kotlin`'s `healthsync-sample/MainActivity.kt`
+   for the full pattern), and give it a real Health Connect manifest fragment:
+   ```bash
+   cp -r app/src/healthSyncNeutral app/src/healthSyncLocal
+   ```
+
+Both `healthsync-local.*.gradle.kts` files and `app/src/healthSyncLocal/` are
+gitignored - `app/build.gradle.kts`/`settings.gradle.kts` only pick them up if
+they exist, and a source-set swap chooses between the neutral and local
+`HealthSyncAdapterBridge` implementation at build-configuration time (the
+Gradle analogue of Swift's `#if canImport(...)`). Once the overlay is in
+place and the adapter registers successfully (which requires the SDK to
+already be initialized - i.e. logged in), the Health Sync screen becomes the
+full Dashboard (Metrics/Body Score/Playground tabs) instead of the raw
+Playground.
+
 ## Project Structure
 [AndroidManifest.xml](bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui) is the main config.  This specifies the main activity.
 

--- a/bwell-kotlin-android/app/build.gradle.kts
+++ b/bwell-kotlin-android/app/build.gradle.kts
@@ -6,6 +6,13 @@ plugins {
     // id("com.google.gms.google-services")
 }
 
+// Health Sync on-device adapter local test overlay - see
+// healthsync-local.app.gradle.kts.example. Adds the published adapter
+// coordinate (and its AndroidManifest merge) ONLY when a developer has
+// created this file locally; absent by default, so this file is never
+// committed and a fresh clone never declares the adapter dependency.
+rootProject.file("healthsync-local.app.gradle.kts").takeIf { it.exists() }?.let { apply(from = it) }
+
 configurations.all {
     resolutionStrategy.cacheChangingModulesFor(0, TimeUnit.SECONDS)
 }
@@ -15,6 +22,36 @@ android {
     // 36 is required by the Health Sync on-device adapter's AndroidX Health
     // Connect dependency (confirmed via its AAR metadata: minCompileSdk=36).
     compileSdk = 36
+
+    sourceSets {
+        // Health Sync on-device adapter bridge: exactly one of these two
+        // sibling source dirs compiles, chosen by whether the untracked
+        // local overlay directory exists. This is the Gradle analogue of
+        // Swift's `#if canImport(BWellHealthSyncAdapterAggregator)` - one
+        // call site (HealthSyncAdapterBridge), two mutually exclusive
+        // implementations, resolved here instead of at compile time, so a
+        // committed clone never even sees the adapter-configuring code.
+        // See healthsync-local.app.gradle.kts.example for how to opt in.
+        val healthSyncLocalSrc = file("src/healthSyncLocal/java")
+        val healthSyncLocalConfigured = healthSyncLocalSrc.exists()
+        getByName("main").java.srcDir(
+            if (healthSyncLocalConfigured) healthSyncLocalSrc else file("src/healthSyncNeutral/java")
+        )
+
+        // Same swap for the manifest fragment carrying the adapter's Health
+        // Connect <queries>/permissions-rationale entries - the debug variant
+        // manifest merges with main, so the committed manifest never
+        // mentions any of it. Kept here (not in the applied overlay script)
+        // because scripts loaded via apply(from=) don't get AGP's
+        // precompiled `android { }` type-safe accessors.
+        getByName("debug").manifest.srcFile(
+            if (healthSyncLocalConfigured) {
+                file("src/healthSyncLocal/AndroidManifest.xml")
+            } else {
+                file("src/healthSyncNeutral/AndroidManifest.xml")
+            }
+        )
+    }
 
     defaultConfig {
         applicationId = "com.bwell.sampleapp"
@@ -78,6 +115,12 @@ dependencies {
 
     // BWell SDK Usage
     implementation("com.bwell:bwell-sdk-kotlin:1.20.0")
+    // Vendor-neutral Health Sync surface (connect/sync/read on-device health
+    // data). No vendor dependency, no gated repo needed - this artifact is
+    // fully public. The on-device adapter that actually talks to a vendor
+    // SDK is deliberately NOT declared here; see healthsync-local.app.gradle.kts.example
+    // for how to add it locally.
+    implementation("com.bwell:bwell-sdk-kotlin-healthsync:1.20.0")
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
@@ -87,6 +130,16 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    // Health Sync Playground: real StateFlow-to-Compose lifecycle wiring
+    // (this app's only other Compose screen, the orphaned MainActivity,
+    // reads state directly rather than via a ViewModel) and the copy-to-
+    // clipboard icon (not in material3's bundled icon set).
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
+    implementation("androidx.compose.material:material-icons-extended")
+    // Playground-only: pretty-printed JSON for endpoint responses, for
+    // visibility while testing - not exposed as SDK surface anywhere.
+    // Matches the internal healthsync-sample's own use of the same library.
+    implementation("com.google.code.gson:gson:2.10.1")
     implementation ("androidx.core:core-ktx:1.12.0")
     implementation ("androidx.appcompat:appcompat:1.6.1")
     implementation ("com.google.android.material:material:1.11.0")

--- a/bwell-kotlin-android/app/build.gradle.kts
+++ b/bwell-kotlin-android/app/build.gradle.kts
@@ -162,6 +162,9 @@ dependencies {
     // implementation("com.google.firebase:firebase-messaging")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.robolectric:robolectric:4.11.1")
+    // HealthSyncPlaygroundViewModelTest/HealthSyncDashboardViewModelTest use
+    // runTest/StandardTestDispatcher to drive viewModelScope deterministically.
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("androidx.test.ext:junit:1.1.5")
     testImplementation("androidx.test.espresso:espresso-core:3.5.1")
     testImplementation("androidx.compose.ui:ui-test-junit4")

--- a/bwell-kotlin-android/app/src/healthSyncNeutral/AndroidManifest.xml
+++ b/bwell-kotlin-android/app/src/healthSyncNeutral/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Neutral half of the Health Sync adapter manifest swap (see
+     app/build.gradle.kts's sourceSets block). No adapter is present in this
+     build, so there is nothing to merge - this file exists only so the
+     debug variant always has a manifest fragment to point at.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/bwell-kotlin-android/app/src/healthSyncNeutral/java/com/bwell/sampleapp/healthsync/HealthSyncAdapterBridge.kt
+++ b/bwell-kotlin-android/app/src/healthSyncNeutral/java/com/bwell/sampleapp/healthsync/HealthSyncAdapterBridge.kt
@@ -1,0 +1,39 @@
+package com.bwell.sampleapp.healthsync
+
+import android.content.Context
+import androidx.fragment.app.Fragment
+
+/**
+ * Single call site for registering an on-device Health Sync adapter with
+ * [com.bwell.healthsync.BWellHealthSync]. Exactly one implementation of
+ * this file compiles at a time - this one (the committed default) or the
+ * one under `src/healthSyncLocal/java/...` - chosen by a source-set swap in
+ * `app/build.gradle.kts` based on whether that local, untracked directory
+ * exists. This is the Gradle analogue of Swift's
+ * `#if canImport(BWellHealthSyncAdapterAggregator)`.
+ *
+ * This is the neutral half: no adapter, no vendor dependency, nothing to
+ * configure. [com.bwell.healthsync.BWellHealthSync.isConfigured] stays
+ * `false`, and the Health Sync UI falls back to its vendor-neutral copy.
+ *
+ * See `healthsync-local.app.gradle.kts.example` at the repo root for how to
+ * opt into the real adapter locally, without touching any committed file.
+ */
+object HealthSyncAdapterBridge {
+    /**
+     * Called once, early in [fragment]'s lifecycle (field initializer /
+     * `onAttach`) - before the fragment reaches `CREATED`, which is the
+     * only window `registerForActivityResult` can be called in. A real
+     * adapter's permission flow (e.g. Health Connect) needs an
+     * `ActivityResultContract` registered here; the neutral build has
+     * nothing to register.
+     */
+    fun registerPermissionLauncher(fragment: Fragment) {
+        // No-op: no on-device adapter is available in this build.
+    }
+
+    /** Registers the adapter with [com.bwell.healthsync.BWellHealthSync], if present. */
+    fun configureIfAvailable(context: Context) {
+        // No-op: no on-device adapter is available in this build.
+    }
+}

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/BWellSampleApplication.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/BWellSampleApplication.kt
@@ -6,6 +6,7 @@ import com.bwell.sampleapp.repository.DataConnectionLabsRepository
 import com.bwell.sampleapp.repository.DataConnectionsRepository
 import com.bwell.sampleapp.repository.HealthSummaryRepository
 import com.bwell.sampleapp.repository.HealthJourneyRepository
+import com.bwell.sampleapp.repository.HealthSyncRepository
 import com.bwell.sampleapp.repository.InsuranceRepository
 import com.bwell.sampleapp.repository.MedicineRepository
 import com.bwell.sampleapp.repository.ProviderRepository
@@ -24,6 +25,7 @@ class BWellSampleApplication : Application() {
      lateinit var medicineRepository: MedicineRepository
      lateinit var healthJourneyRepository: HealthJourneyRepository
     lateinit var insuranceRepository: InsuranceRepository
+    lateinit var healthSyncRepository: HealthSyncRepository
 
     override fun onCreate() {
         super.onCreate()
@@ -41,6 +43,7 @@ class BWellSampleApplication : Application() {
         healthSummaryRepository = HealthSummaryRepository( applicationContext)
         healthJourneyRepository = HealthJourneyRepository()
         insuranceRepository = InsuranceRepository(applicationContext)
+        healthSyncRepository = HealthSyncRepository()
 
     }
 }

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/NavigationActivity.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/NavigationActivity.kt
@@ -60,7 +60,7 @@ class NavigationActivity : AppCompatActivity() {
         val navView: NavigationView = binding.navView
         navController = findNavController(R.id.nav_host_fragment_content_navigation)
         appBarConfiguration = AppBarConfiguration(
-            setOf(R.id.nav_login, R.id.nav_home, R.id.nav_data_connections, R.id.nav_health_summary, R.id.nav_health_journey, R.id.nav_insurance, R.id.nav_profile, R.id.nav_labs, R.id.nav_medicines
+            setOf(R.id.nav_login, R.id.nav_home, R.id.nav_data_connections, R.id.nav_health_summary, R.id.nav_health_journey, R.id.nav_insurance, R.id.nav_profile, R.id.nav_labs, R.id.nav_medicines, R.id.nav_health_sync
             ), drawerLayout
         )
         setupActionBarWithNavController(navController, appBarConfiguration)

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncDashboardScreen.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncDashboardScreen.kt
@@ -1,0 +1,201 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+private enum class DashboardTab(val title: String) {
+    METRICS("Metrics"),
+    BODY_SCORE("Body Score"),
+    PLAYGROUND("Playground"),
+}
+
+/**
+ * Shown instead of the raw Playground when an on-device adapter is
+ * configured - ported from Swift's HealthSyncDashboardView. A polished
+ * Metrics/Body Score view for the data that adapter actually produces, plus
+ * the Playground itself as a third tab for anyone who still wants the raw
+ * test bench.
+ */
+@Composable
+fun HealthSyncDashboardScreen(
+    dashboardViewModel: HealthSyncDashboardViewModel,
+    playgroundViewModel: HealthSyncPlaygroundViewModel,
+    modifier: Modifier = Modifier,
+) {
+    LaunchedEffect(Unit) { dashboardViewModel.attach() }
+    var selectedTab by remember { mutableIntStateOf(0) }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TabRow(selectedTabIndex = selectedTab) {
+            DashboardTab.entries.forEachIndexed { index, tab ->
+                Tab(
+                    selected = selectedTab == index,
+                    onClick = { selectedTab = index },
+                    text = { Text(tab.title) },
+                )
+            }
+        }
+
+        when (DashboardTab.entries[selectedTab]) {
+            DashboardTab.METRICS -> MetricsTab(dashboardViewModel)
+            DashboardTab.BODY_SCORE -> BodyScoreTab(dashboardViewModel)
+            DashboardTab.PLAYGROUND -> HealthSyncPlaygroundScreen(playgroundViewModel)
+        }
+    }
+}
+
+@Composable
+private fun MetricsTab(viewModel: HealthSyncDashboardViewModel) {
+    val state by viewModel.metricsState.collectAsStateWithLifecycle()
+    when (val current = state) {
+        is SyncGatedState.Loading -> CenteredProgress()
+        is SyncGatedState.Empty -> SyncPromptView(progress = null, errorMessage = current.errorMessage, onSync = viewModel::syncMetrics)
+        is SyncGatedState.Syncing -> SyncPromptView(progress = current.progress, errorMessage = null, onSync = viewModel::syncMetrics)
+        is SyncGatedState.Loaded -> LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(current.value) { group ->
+                Card(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp)) {
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(
+                            group.coding?.display ?: group.name ?: "Metric",
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        group.sourceDisplay?.firstOrNull()?.let {
+                            Text(it, style = MaterialTheme.typography.bodySmall)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BodyScoreTab(viewModel: HealthSyncDashboardViewModel) {
+    val state by viewModel.bodyScoreState.collectAsStateWithLifecycle()
+    when (val current = state) {
+        is SyncGatedState.Loading -> CenteredProgress()
+        is SyncGatedState.Empty -> SyncPromptView(progress = null, errorMessage = current.errorMessage, onSync = viewModel::syncBodyScore)
+        is SyncGatedState.Syncing -> SyncPromptView(progress = current.progress, errorMessage = null, onSync = viewModel::syncBodyScore)
+        is SyncGatedState.Loaded -> {
+            val score = current.value
+            LazyColumn(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+                item {
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        Column(
+                            modifier = Modifier.fillMaxWidth().padding(16.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            Text("Biological Age", style = MaterialTheme.typography.bodySmall)
+                            Text(
+                                score.bioAge?.let { "%.0f".format(it) } ?: "—",
+                                style = MaterialTheme.typography.displaySmall,
+                            )
+                        }
+                    }
+                }
+                items(score.bodySystems.orEmpty()) { system ->
+                    Card(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+                        Column(modifier = Modifier.padding(12.dp)) {
+                            Text(system.title ?: system.bodySystemId ?: "Body system")
+                            system.grade?.let { Text("Grade $it", style = MaterialTheme.typography.bodySmall) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CenteredProgress() {
+    Box(modifier = Modifier.fillMaxSize()) {
+        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+    }
+}
+
+/**
+ * `progress` non-null means actively syncing - shows the real record count
+ * sync() returned, plus a numeric attempt counter, not just a spinner with
+ * no way to tell if it's stuck. Ported from Swift's SyncPromptView.
+ */
+@Composable
+private fun SyncPromptView(progress: SyncProgress?, errorMessage: String?, onSync: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.align(Alignment.Center).padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(Icons.Filled.Sync, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
+
+            if (progress != null) {
+                Text("Syncing with b.well…", style = MaterialTheme.typography.titleMedium)
+                val recordsSynced = progress.recordsSynced
+                if (recordsSynced != null) {
+                    Text(
+                        "Synced $recordsSynced record${if (recordsSynced == 1) "" else "s"} from your device. " +
+                            "Waiting for b.well to process ${if (recordsSynced == 0) "" else "them"}…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    Text(
+                        "Reading from your device…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (progress.attempt > 0) {
+                    LinearProgressIndicator(
+                        progress = progress.attempt.toFloat() / progress.maxAttempts,
+                        modifier = Modifier.width(200.dp).padding(top = 12.dp),
+                    )
+                    Text(
+                        "Checking (${progress.attempt}/${progress.maxAttempts})",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    CircularProgressIndicator(modifier = Modifier.padding(top = 12.dp))
+                }
+            } else {
+                Text(
+                    if (errorMessage != null) "Sync incomplete" else "No data yet",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                errorMessage?.let {
+                    Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Button(onClick = onSync, modifier = Modifier.padding(top = 12.dp)) {
+                    Text("Sync with b.well")
+                }
+            }
+        }
+    }
+}

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncDashboardViewModel.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncDashboardViewModel.kt
@@ -1,5 +1,6 @@
 package com.bwell.sampleapp.activities.ui.healthsync
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bwell.common.models.domain.healthdata.healthsummary.devicemetrics.DeviceMetricsGroup
@@ -46,6 +47,8 @@ class HealthSyncDashboardViewModel(private val repository: HealthSyncRepository)
         // a single re-fetch, but give up rather than polling forever.
         const val POLL_INTERVAL_MS = 10_000L
         const val MAX_POLL_ATTEMPTS = 30
+
+        const val TAG = "HealthSyncDashboard"
     }
 
     private val _metricsState = MutableStateFlow<SyncGatedState<List<DeviceMetricsGroup>>>(SyncGatedState.Loading)
@@ -99,16 +102,20 @@ class HealthSyncDashboardViewModel(private val repository: HealthSyncRepository)
 
     // Reachable before login (SDK not yet initialized) - BaseSdk's accessors
     // throw synchronously in that case, not a BWellResult error, so both
-    // fetchers treat that the same as "no data yet" rather than crashing.
+    // fetchers treat that the same as "no data yet" rather than crashing -
+    // the exception is still logged, so a genuine misconfiguration is
+    // distinguishable from the expected pre-login case.
     private suspend fun fetchMetrics(): List<DeviceMetricsGroup> = try {
         (repository.getDeviceMetricsGroups() as? BWellResult.ResourceCollection)?.data.orEmpty()
     } catch (e: Exception) {
+        Log.w(TAG, "fetchMetrics failed", e)
         emptyList()
     }
 
     private suspend fun fetchBodyScore(): HealthScore? = try {
         (repository.getHealthScore() as? BWellResult.SingleResource)?.data?.resource
     } catch (e: Exception) {
+        Log.w(TAG, "fetchBodyScore failed", e)
         null
     }
 

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncDashboardViewModel.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncDashboardViewModel.kt
@@ -1,6 +1,5 @@
 package com.bwell.sampleapp.activities.ui.healthsync
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bwell.common.models.domain.healthdata.healthsummary.devicemetrics.DeviceMetricsGroup
@@ -100,24 +99,17 @@ class HealthSyncDashboardViewModel(private val repository: HealthSyncRepository)
         }
     }
 
-    // Reachable before login (SDK not yet initialized) - BaseSdk's accessors
-    // throw synchronously in that case, not a BWellResult error, so both
-    // fetchers treat that the same as "no data yet" rather than crashing -
-    // the exception is still logged, so a genuine misconfiguration is
-    // distinguishable from the expected pre-login case.
-    private suspend fun fetchMetrics(): List<DeviceMetricsGroup> = try {
-        (repository.getDeviceMetricsGroups() as? BWellResult.ResourceCollection)?.data.orEmpty()
-    } catch (e: Exception) {
-        Log.w(TAG, "fetchMetrics failed", e)
-        emptyList()
-    }
+    // Reachable before login - see guardedCall's doc. Both fetchers treat a
+    // throw the same as "no data yet" rather than crashing.
+    private suspend fun fetchMetrics(): List<DeviceMetricsGroup> =
+        guardedCall(TAG, "fetchMetrics", emptyList()) {
+            (repository.getDeviceMetricsGroups() as? BWellResult.ResourceCollection)?.data.orEmpty()
+        }
 
-    private suspend fun fetchBodyScore(): HealthScore? = try {
-        (repository.getHealthScore() as? BWellResult.SingleResource)?.data?.resource
-    } catch (e: Exception) {
-        Log.w(TAG, "fetchBodyScore failed", e)
-        null
-    }
+    private suspend fun fetchBodyScore(): HealthScore? =
+        guardedCall(TAG, "fetchBodyScore", null) {
+            (repository.getHealthScore() as? BWellResult.SingleResource)?.data?.resource
+        }
 
     private sealed interface PollOutcome<out Value> {
         data class Found<Value>(val value: Value) : PollOutcome<Value>
@@ -166,7 +158,10 @@ class HealthSyncDashboardViewModel(private val repository: HealthSyncRepository)
             onProgress(progress)
             val value = fetch()
             if (!isEmpty(value)) return PollOutcome.Found(value)
-            kotlinx.coroutines.delay(POLL_INTERVAL_MS)
+            // Skip the pacing delay after the last attempt - there's no next
+            // attempt to pace towards, so it was just a dead 10s wait
+            // immediately before the give-up message.
+            if (index < MAX_POLL_ATTEMPTS - 1) kotlinx.coroutines.delay(POLL_INTERVAL_MS)
         }
 
         val stillEmptyMessage = if ((progress.recordsSynced ?: 0) == 0) {

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncDashboardViewModel.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncDashboardViewModel.kt
@@ -1,0 +1,191 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bwell.common.models.domain.healthdata.healthsummary.devicemetrics.DeviceMetricsGroup
+import com.bwell.common.models.domain.healthdata.healthsummary.healthscore.HealthScore
+import com.bwell.common.models.responses.BWellResult
+import com.bwell.sampleapp.repository.HealthSyncRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/** Live progress while a sync-then-poll is in flight - ported from Swift's SyncProgress. */
+data class SyncProgress(
+    val recordsSynced: Int? = null,
+    val attempt: Int = 0,
+    val maxAttempts: Int,
+)
+
+/** Ported from Swift's SyncGatedState<Value>. */
+sealed interface SyncGatedState<out Value> {
+    data object Loading : SyncGatedState<Nothing>
+    data class Empty(val errorMessage: String? = null) : SyncGatedState<Nothing>
+    data class Syncing(val progress: SyncProgress) : SyncGatedState<Nothing>
+    data class Loaded<Value>(val value: Value) : SyncGatedState<Value>
+}
+
+/**
+ * Backs [HealthSyncDashboardScreen] (the Metrics/Body Score tabs shown when
+ * an on-device adapter is configured) - ported from Swift's
+ * HealthSyncDashboardViewModel. Shares the same "fetch, and if empty let the
+ * user trigger sync() then poll until data shows up" shape for both tabs,
+ * factored into [triggerSyncThenPoll] instead of duplicating it.
+ *
+ * DCON-4936 (session-conflict-on-user-switch) is not yet in a Kotlin SDK
+ * release (bwell-sdk-kotlin 1.20.0 predates PR #955) - [reconcileSessionIfNeeded]
+ * is the same TEMPORARY, public-API-only workaround Swift already has in
+ * HealthSyncSessionReconciliation.swift. Delete both once #955 ships.
+ */
+class HealthSyncDashboardViewModel(private val repository: HealthSyncRepository) : ViewModel() {
+
+    private companion object {
+        // Server-side processing after sync() isn't instant (matches the Read
+        // Data note elsewhere: "Data appears within 5 min") - poll instead of
+        // a single re-fetch, but give up rather than polling forever.
+        const val POLL_INTERVAL_MS = 10_000L
+        const val MAX_POLL_ATTEMPTS = 30
+    }
+
+    private val _metricsState = MutableStateFlow<SyncGatedState<List<DeviceMetricsGroup>>>(SyncGatedState.Loading)
+    val metricsState: StateFlow<SyncGatedState<List<DeviceMetricsGroup>>> = _metricsState.asStateFlow()
+
+    private val _bodyScoreState = MutableStateFlow<SyncGatedState<HealthScore>>(SyncGatedState.Loading)
+    val bodyScoreState: StateFlow<SyncGatedState<HealthScore>> = _bodyScoreState.asStateFlow()
+
+    private var attached = false
+
+    fun attach() {
+        if (attached) return
+        attached = true
+        viewModelScope.launch { refreshMetrics() }
+        viewModelScope.launch { refreshBodyScore() }
+    }
+
+    suspend fun refreshMetrics() {
+        val groups = fetchMetrics()
+        _metricsState.value = if (groups.isEmpty()) SyncGatedState.Empty() else SyncGatedState.Loaded(groups)
+    }
+
+    suspend fun refreshBodyScore() {
+        val score = fetchBodyScore()
+        _bodyScoreState.value = if (score == null) SyncGatedState.Empty() else SyncGatedState.Loaded(score)
+    }
+
+    fun syncMetrics() {
+        viewModelScope.launch {
+            when (val outcome = triggerSyncThenPoll(fetch = ::fetchMetrics, isEmpty = { it.isEmpty() }) {
+                _metricsState.value = SyncGatedState.Syncing(it)
+            }) {
+                is PollOutcome.Found -> _metricsState.value = SyncGatedState.Loaded(outcome.value)
+                is PollOutcome.GaveUp -> _metricsState.value = SyncGatedState.Empty(outcome.errorMessage)
+            }
+        }
+    }
+
+    fun syncBodyScore() {
+        viewModelScope.launch {
+            when (
+                val outcome = triggerSyncThenPoll(fetch = ::fetchBodyScore, isEmpty = { it == null }) {
+                    _bodyScoreState.value = SyncGatedState.Syncing(it)
+                }
+            ) {
+                is PollOutcome.Found -> outcome.value?.let { _bodyScoreState.value = SyncGatedState.Loaded(it) }
+                is PollOutcome.GaveUp -> _bodyScoreState.value = SyncGatedState.Empty(outcome.errorMessage)
+            }
+        }
+    }
+
+    // Reachable before login (SDK not yet initialized) - BaseSdk's accessors
+    // throw synchronously in that case, not a BWellResult error, so both
+    // fetchers treat that the same as "no data yet" rather than crashing.
+    private suspend fun fetchMetrics(): List<DeviceMetricsGroup> = try {
+        (repository.getDeviceMetricsGroups() as? BWellResult.ResourceCollection)?.data.orEmpty()
+    } catch (e: Exception) {
+        emptyList()
+    }
+
+    private suspend fun fetchBodyScore(): HealthScore? = try {
+        (repository.getHealthScore() as? BWellResult.SingleResource)?.data?.resource
+    } catch (e: Exception) {
+        null
+    }
+
+    private sealed interface PollOutcome<out Value> {
+        data class Found<Value>(val value: Value) : PollOutcome<Value>
+        data class GaveUp(val errorMessage: String?) : PollOutcome<Nothing>
+    }
+
+    /**
+     * Triggers a real sync() over the standard window, reports its actual
+     * record count via [onProgress] immediately, then polls [fetch] -
+     * reporting each attempt - until it returns a non-empty value or
+     * [MAX_POLL_ATTEMPTS] is reached. A sync() failure is terminal (surfaced,
+     * not silently swallowed) rather than polling blind against a call that
+     * never ran.
+     */
+    private suspend fun <Value> triggerSyncThenPoll(
+        fetch: suspend () -> Value,
+        isEmpty: (Value) -> Boolean,
+        onProgress: (SyncProgress) -> Unit,
+    ): PollOutcome<Value> {
+        var progress = SyncProgress(maxAttempts = MAX_POLL_ATTEMPTS)
+        onProgress(progress)
+
+        try {
+            reconcileSessionIfNeeded()
+            val connectResult = repository.connect()
+            if (!connectResult.success()) {
+                return PollOutcome.GaveUp("Sync failed: ${connectResult.error?.message()}")
+            }
+            val permissionsResult = repository.requestPermissions()
+            if (!permissionsResult.success()) {
+                return PollOutcome.GaveUp("Sync failed: ${permissionsResult.error?.message()}")
+            }
+            val syncResult = repository.sync()
+            if (!syncResult.success()) {
+                return PollOutcome.GaveUp("Sync failed: ${syncResult.error?.message()}")
+            }
+            val counts = (syncResult as? BWellResult.SingleResource)?.data
+            progress = progress.copy(recordsSynced = counts?.total ?: 0)
+            onProgress(progress)
+        } catch (e: Exception) {
+            return PollOutcome.GaveUp("Sync failed: ${e.message}")
+        }
+
+        repeat(MAX_POLL_ATTEMPTS) { index ->
+            progress = progress.copy(attempt = index + 1)
+            onProgress(progress)
+            val value = fetch()
+            if (!isEmpty(value)) return PollOutcome.Found(value)
+            kotlinx.coroutines.delay(POLL_INTERVAL_MS)
+        }
+
+        val stillEmptyMessage = if ((progress.recordsSynced ?: 0) == 0) {
+            "Synced 0 records from your device - nothing to process. Check connect/requestPermissions ran first."
+        } else {
+            "Synced ${progress.recordsSynced} records, but b.well hasn't finished processing them yet. Try again shortly."
+        }
+        return PollOutcome.GaveUp(stillEmptyMessage)
+    }
+
+    /**
+     * Public-API-only reconciliation, matching what bwell-sdk PR #955 does
+     * inside the SDK itself: currentUser() (the live on-device session's
+     * user, or null on a fresh install/device) vs getDeviceUserStatus()
+     * (whether this logged-in b.well user already has a device-user record,
+     * and if so, which one). Ends the stale session first if they disagree.
+     */
+    private suspend fun reconcileSessionIfNeeded() {
+        val currentUserResult = repository.currentUser()
+        val currentUser = (currentUserResult as? BWellResult.SingleResource)?.data ?: return
+
+        val statusResult = repository.getDeviceUserStatus(HealthSyncPlaygroundViewModel.PLAYGROUND_CONNECTION_ID)
+        val status = (statusResult as? BWellResult.SingleResource)?.data ?: return
+        val matches = status.exists && status.deviceUserId == currentUser.userId
+        if (!matches) {
+            repository.endSession()
+        }
+    }
+}

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncGuardedCall.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncGuardedCall.kt
@@ -1,0 +1,20 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import android.util.Log
+
+/**
+ * Runs [block], returning [default] and logging if it throws.
+ *
+ * Every Health Sync SDK-backed loader/fetcher needs this: the feature is
+ * reachable before login, and BaseSdk's accessors throw synchronously in
+ * that state rather than returning a BWellResult error the caller could
+ * branch on normally. Centralized so a future call site inherits the guard
+ * instead of needing to remember to re-add it.
+ */
+suspend fun <T> guardedCall(tag: String, what: String, default: T, block: suspend () -> T): T =
+    try {
+        block()
+    } catch (e: Exception) {
+        Log.w(tag, "$what failed", e)
+        default
+    }

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundEndpoint.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundEndpoint.kt
@@ -1,0 +1,178 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+/**
+ * Ported from bwell-swift-ios's HealthSyncPlaygroundEndpoint.swift - same 14
+ * endpoints (+ getCurrentUser, 15 total) grouped identically, same
+ * user-facing copy verbatim. [isBlocked]/[blockedReason] are intentionally
+ * NOT stored here (Swift keeps them static `false`/`nil`, unused) - whether
+ * an endpoint is blocked depends on runtime state
+ * ([com.bwell.healthsync.BWellHealthSync.isConfigured]), so it's computed by
+ * [HealthSyncGating] instead of baked into this otherwise-static spec.
+ */
+enum class HealthSyncPlaygroundGroup(val title: String) {
+    MOBILE_SYNC("Mobile Sync"),
+    CLOUD_PROVIDERS("Cloud Providers"),
+    READ_DATA("Read Data"),
+}
+
+enum class HealthSyncPlaygroundEndpoint(
+    val title: String,
+    val group: HealthSyncPlaygroundGroup,
+    val explanation: String,
+    val documentationPath: String?,
+    val documentationSummary: String?,
+    val parameterInfo: String? = null,
+) {
+    CONNECT(
+        title = "connect",
+        group = HealthSyncPlaygroundGroup.MOBILE_SYNC,
+        explanation = "Starts syncing your health data with b.well. Calls setupMobileSync, then starts your on-device session.",
+        documentationPath = "connect-mobile-sync",
+        documentationSummary = "The connect method in the b.well SDK establishes an on-device health sync session for a given source, composing the underlying provisioning steps automatically. This is the recommended entry point for connecting an on-device health source — prefer it over calling setupMobileSync directly.",
+    ),
+    DISCONNECT(
+        title = "disconnect",
+        group = HealthSyncPlaygroundGroup.MOBILE_SYNC,
+        explanation = "Stops syncing and removes your connection from b.well. Ends your on-device session, then calls deleteConnection.",
+        documentationPath = "disconnect-mobile-sync",
+        documentationSummary = "The disconnect method in the b.well SDK ends an on-device health sync session and removes the underlying connection.",
+    ),
+    REQUEST_PERMISSIONS(
+        title = "requestPermissions",
+        group = HealthSyncPlaygroundGroup.MOBILE_SYNC,
+        explanation = "Asks your device for permission to read your health data. Calls requestPermissions.",
+        documentationPath = "request-permissions",
+        documentationSummary = "The requestPermissions method in the b.well SDK requests user authorization for the specified health data types from the connected on-device health source.",
+    ),
+    SYNC(
+        title = "sync",
+        group = HealthSyncPlaygroundGroup.MOBILE_SYNC,
+        explanation = "Reads your health data from this device and uploads it to b.well. Calls sync.",
+        documentationPath = "sync-health-data",
+        documentationSummary = "The sync method in the b.well SDK reads health data of the specified types, within a given date range, from the connected on-device health source.",
+    ),
+    GET_CURRENT_USER(
+        title = "getCurrentUser",
+        group = HealthSyncPlaygroundGroup.MOBILE_SYNC,
+        explanation = "Shows the user of your active on-device session, if any. Calls currentUser.",
+        documentationPath = null,
+        documentationSummary = null,
+    ),
+    SETUP_MOBILE_SYNC(
+        title = "setupMobileSync",
+        group = HealthSyncPlaygroundGroup.MOBILE_SYNC,
+        explanation = "Sets up the credentials this device needs to sync health data. Calls setupMobileSync.",
+        documentationPath = "setup-mobile-sync",
+        documentationSummary = "The setupMobileSync method in the b.well SDK provisions the backend credentials needed to sync data from an on-device health source (e.g. a phone or wearable's local health store) for a given connection.",
+    ),
+    GET_DEVICE_USER_STATUS(
+        title = "getDeviceUserStatus",
+        group = HealthSyncPlaygroundGroup.MOBILE_SYNC,
+        explanation = "Checks whether this connection already has a device user set up. Calls getDeviceUserStatus.",
+        documentationPath = "get-device-user-status",
+        documentationSummary = "The getDeviceUserStatus method in the b.well SDK checks whether a device-user record already exists for a given connection, and returns its identifier if so.",
+    ),
+    GET_OAUTH_URL(
+        title = "getOauthUrl",
+        group = HealthSyncPlaygroundGroup.CLOUD_PROVIDERS,
+        explanation = "Gets a link to authorize a cloud health provider account. Calls getOauthUrl.",
+        documentationPath = null,
+        documentationSummary = null,
+        parameterInfo = "Provider - pick a cloud health provider from the dropdown.",
+    ),
+    GET_DEVICE_PROVIDER_STATUS(
+        title = "getDeviceProviderStatus",
+        group = HealthSyncPlaygroundGroup.CLOUD_PROVIDERS,
+        explanation = "Checks whether a specific health provider is already connected. Calls getDeviceProviderStatus.",
+        documentationPath = "get-device-provider-status",
+        documentationSummary = "The getDeviceProviderStatus method in the b.well SDK performs a lightweight, database-only check of whether a given connection is currently connected, without making an external network call to the provider itself.",
+        parameterInfo = "Provider - pick a cloud health provider from the dropdown.",
+    ),
+    GET_DEVICE_PROVIDERS(
+        title = "getDeviceProviders",
+        group = HealthSyncPlaygroundGroup.CLOUD_PROVIDERS,
+        explanation = "Lists every health data provider available to connect. Calls getDeviceProviders.",
+        documentationPath = "get-device-providers",
+        documentationSummary = "The getDeviceProviders method in the b.well SDK retrieves the list of health data providers available for connection, along with each provider's connection status.",
+    ),
+    DELETE_CONNECTION(
+        title = "deleteConnection",
+        group = HealthSyncPlaygroundGroup.CLOUD_PROVIDERS,
+        explanation = "Permanently deletes a connection and all its data. Calls deleteConnection.",
+        documentationPath = null,
+        documentationSummary = null,
+        parameterInfo = "Provider - pick a provider to prefill the connection id.\nconnectionId - the connection to permanently delete.",
+    ),
+    GET_DEVICE_METRICS(
+        title = "getDeviceMetrics",
+        group = HealthSyncPlaygroundGroup.READ_DATA,
+        explanation = "Returns your raw synced health records. Calls getDeviceMetrics.",
+        documentationPath = "device-metrics",
+        documentationSummary = "The getDeviceMetrics method in the b.well SDK retrieves a flat, paginated list of raw Observation resources synced from a connected device or on-device health source.",
+        parameterInfo = "Code - which metric type to filter by. Populated automatically by calling getDeviceMetricsGroups() each time this card appears. Disabled until at least one code comes back - sync some data first (Mobile Sync group above).",
+    ),
+    GET_DEVICE_METRICS_GROUPS(
+        title = "getDeviceMetricsGroups",
+        group = HealthSyncPlaygroundGroup.READ_DATA,
+        explanation = "Returns your synced health records grouped by metric type. Calls getDeviceMetricsGroups.",
+        documentationPath = "device-metrics-groups",
+        documentationSummary = "The getDeviceMetricsGroups method in the b.well SDK fetches a list of DeviceMetricsGroup resources, each representing connected-device metrics organized into a named group.",
+    ),
+    GET_HEALTH_SCORE(
+        title = "getHealthScore",
+        group = HealthSyncPlaygroundGroup.READ_DATA,
+        explanation = "Returns your overall health score. Calls getHealthScore.",
+        documentationPath = "health-score",
+        documentationSummary = "The getHealthScore method in the b.well SDK retrieves the authenticated patient's overall health score, including its trend, contributing body systems, and daily score history.",
+    ),
+    GET_BODY_SYSTEM_SCORE(
+        title = "getBodySystemScore",
+        group = HealthSyncPlaygroundGroup.READ_DATA,
+        explanation = "Returns a health score for one body system. Calls getBodySystemScore.",
+        documentationPath = "body-system-score",
+        documentationSummary = "The getBodySystemScore method in the b.well SDK retrieves a detailed score for a single body system (e.g. cardiovascular, sleep, respiratory, musculoskeletal) for the authenticated patient.",
+        parameterInfo = "Body system - which body system to score. Populated automatically by calling getHealthScore() each time this card appears, from its contributing body systems. Disabled until at least one comes back - that requires enough synced data for a health score to be computed.",
+    ),
+    ;
+
+    val documentationUrl: String?
+        get() = documentationPath?.let { "https://developer.bwell.com/docs/$it" }
+}
+
+/**
+ * The 5 endpoints that call [com.bwell.healthsync.HealthSyncManager]
+ * directly and so require an on-device adapter to be registered via
+ * [com.bwell.healthsync.BWellHealthSync.configure]. Everything else
+ * (setupMobileSync/getDeviceUserStatus, Cloud Providers, Read Data) calls
+ * core SDK managers that work in a credential-less build once logged in.
+ */
+private val HEALTH_SYNC_GATED_ENDPOINTS = setOf(
+    HealthSyncPlaygroundEndpoint.CONNECT,
+    HealthSyncPlaygroundEndpoint.DISCONNECT,
+    HealthSyncPlaygroundEndpoint.REQUEST_PERMISSIONS,
+    HealthSyncPlaygroundEndpoint.SYNC,
+    HealthSyncPlaygroundEndpoint.GET_CURRENT_USER,
+)
+
+/** Locked copy - must match Swift's HealthSyncPlaygroundViewModel verbatim. */
+const val HEALTH_SYNC_NOT_CONFIGURED_MESSAGE =
+    "Health Sync on-device sync: some endpoints require a third-party health-data provider " +
+        "integration. Credential provisioning for this integration is currently under " +
+        "consideration — these endpoints will show a 'Health Sync Credentials Required' " +
+        "state until that's finalized."
+
+/**
+ * Pre-emptive card-level gating: unlike Swift (which still lets a tap
+ * happen and catches the resulting error), an unconfigured build disables
+ * the 5 gated endpoints' Run buttons outright, so
+ * [com.bwell.healthsync.BWellHealthSync]'s consuming code is never even
+ * invoked while unconfigured (it would throw `IllegalStateException`, not
+ * return a catchable error - see BWellHealthSync.kt).
+ */
+object HealthSyncGating {
+    fun isBlocked(endpoint: HealthSyncPlaygroundEndpoint, configured: Boolean): Boolean =
+        !configured && endpoint in HEALTH_SYNC_GATED_ENDPOINTS
+
+    fun blockedReason(endpoint: HealthSyncPlaygroundEndpoint, configured: Boolean): String? =
+        if (isBlocked(endpoint, configured)) HEALTH_SYNC_NOT_CONFIGURED_MESSAGE else null
+}

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundFragment.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundFragment.kt
@@ -1,0 +1,50 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.bwell.sampleapp.BWellSampleApplication
+import com.bwell.sampleapp.healthsync.HealthSyncAdapterBridge
+import com.bwell.sampleapp.ui.theme.MyTestAppTheme
+import com.bwell.sampleapp.viewmodel.HealthSyncViewModelFactory
+
+/**
+ * Hosts [HealthSyncRootScreen] in Compose - this app's Fragment/XML-nav-graph
+ * architecture is otherwise unchanged; this is the one entry point where a
+ * Fragment renders Compose content instead of a ViewBinding layout.
+ */
+class HealthSyncPlaygroundFragment : Fragment() {
+
+    init {
+        // Must run before CREATED - see HealthSyncAdapterBridge's doc.
+        HealthSyncAdapterBridge.registerPermissionLauncher(this)
+    }
+
+    private lateinit var playgroundViewModel: HealthSyncPlaygroundViewModel
+    private lateinit var dashboardViewModel: HealthSyncDashboardViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        HealthSyncAdapterBridge.configureIfAvailable(requireContext().applicationContext)
+
+        val repository = (requireActivity().application as BWellSampleApplication).healthSyncRepository
+        val factory = HealthSyncViewModelFactory(repository)
+        playgroundViewModel = ViewModelProvider(this, factory)[HealthSyncPlaygroundViewModel::class.java]
+        dashboardViewModel = ViewModelProvider(this, factory)[HealthSyncDashboardViewModel::class.java]
+
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MyTestAppTheme {
+                    HealthSyncRootScreen(playgroundViewModel, dashboardViewModel)
+                }
+            }
+        }
+    }
+}

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundScreen.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundScreen.kt
@@ -103,7 +103,8 @@ fun HealthSyncPlaygroundScreen(viewModel: HealthSyncPlaygroundViewModel, modifie
                         endpoint = endpoint,
                         deviceProviderOptions = deviceProviderOptions,
                         selectedDeviceProvider = selectedDeviceProvider,
-                        onSelectDeviceProvider = viewModel::onSelectDeviceProvider,
+                        onSelectDeviceProviderForLookup = viewModel::onSelectDeviceProviderForLookup,
+                        onSelectDeviceProviderForDelete = viewModel::onSelectDeviceProviderForDelete,
                         deleteConnectionIdInput = deleteConnectionIdInput,
                         onDeleteConnectionIdInputChanged = viewModel::onDeleteConnectionIdInputChanged,
                         deviceMetricsCodeOptions = deviceMetricsCodeOptions,
@@ -124,7 +125,8 @@ private fun EndpointInputs(
     endpoint: HealthSyncPlaygroundEndpoint,
     deviceProviderOptions: List<com.bwell.common.models.domain.data.DeviceProvider>,
     selectedDeviceProvider: com.bwell.common.models.domain.data.DeviceProvider?,
-    onSelectDeviceProvider: (com.bwell.common.models.domain.data.DeviceProvider) -> Unit,
+    onSelectDeviceProviderForLookup: (com.bwell.common.models.domain.data.DeviceProvider) -> Unit,
+    onSelectDeviceProviderForDelete: (com.bwell.common.models.domain.data.DeviceProvider) -> Unit,
     deleteConnectionIdInput: String,
     onDeleteConnectionIdInputChanged: (String) -> Unit,
     deviceMetricsCodeOptions: List<PlaygroundCodeOption>,
@@ -143,7 +145,7 @@ private fun EndpointInputs(
                 options = deviceProviderOptions,
                 selectedLabel = selectedDeviceProvider?.name,
                 displayText = { it.name },
-                onSelect = onSelectDeviceProvider,
+                onSelect = onSelectDeviceProviderForLookup,
             )
         }
         HealthSyncPlaygroundEndpoint.DELETE_CONNECTION -> {
@@ -152,7 +154,7 @@ private fun EndpointInputs(
                 options = deviceProviderOptions,
                 selectedLabel = selectedDeviceProvider?.name,
                 displayText = { it.name },
-                onSelect = onSelectDeviceProvider,
+                onSelect = onSelectDeviceProviderForDelete,
             )
             OutlinedTextField(
                 value = deleteConnectionIdInput,

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundScreen.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundScreen.kt
@@ -1,0 +1,226 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * Ported from Swift's HealthSyncPlaygroundView: one group per
+ * [HealthSyncPlaygroundGroup], the Read Data note banner, and a card per
+ * endpoint with whatever input the endpoint needs.
+ */
+@Composable
+fun HealthSyncPlaygroundScreen(viewModel: HealthSyncPlaygroundViewModel, modifier: Modifier = Modifier) {
+    LaunchedEffect(Unit) { viewModel.attach() }
+
+    val results by viewModel.results.collectAsStateWithLifecycle()
+    val configured by viewModel.configured.collectAsStateWithLifecycle()
+    val deviceProviderOptions by viewModel.deviceProviderOptions.collectAsStateWithLifecycle()
+    val selectedDeviceProvider by viewModel.selectedDeviceProvider.collectAsStateWithLifecycle()
+    val deleteConnectionIdInput by viewModel.deleteConnectionIdInput.collectAsStateWithLifecycle()
+    val deviceMetricsCodeOptions by viewModel.deviceMetricsCodeOptions.collectAsStateWithLifecycle()
+    val selectedDeviceMetricsCode by viewModel.selectedDeviceMetricsCode.collectAsStateWithLifecycle()
+    val bodySystemOptions by viewModel.bodySystemOptions.collectAsStateWithLifecycle()
+    val selectedBodySystemId by viewModel.selectedBodySystemId.collectAsStateWithLifecycle()
+
+    fun isRunDisabled(endpoint: HealthSyncPlaygroundEndpoint): Boolean = when (endpoint) {
+        HealthSyncPlaygroundEndpoint.GET_OAUTH_URL,
+        HealthSyncPlaygroundEndpoint.GET_DEVICE_PROVIDER_STATUS,
+        -> selectedDeviceProvider == null
+        HealthSyncPlaygroundEndpoint.GET_DEVICE_METRICS -> deviceMetricsCodeOptions.isEmpty()
+        HealthSyncPlaygroundEndpoint.GET_BODY_SYSTEM_SCORE -> bodySystemOptions.isEmpty()
+        else -> false
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        item {
+            Column {
+                Text(
+                    "API Playground",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    "Test bench — run any endpoint independently, raw response shown per card.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        for (group in HealthSyncPlaygroundGroup.entries) {
+            val endpoints = HealthSyncPlaygroundEndpoint.entries.filter { it.group == group }
+            item {
+                Text(
+                    group.title.uppercase(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (group == HealthSyncPlaygroundGroup.READ_DATA) {
+                item {
+                    PlaygroundNoteBanner(
+                        "Run connect, requestPermissions, and sync first (Mobile Sync group above) — " +
+                            "Read Data reflects whatever was last synced. Data appears within 5 min.",
+                    )
+                }
+            }
+            items(endpoints) { endpoint ->
+                PlaygroundCard(
+                    endpoint = endpoint,
+                    state = results[endpoint] ?: PlaygroundCardState.Idle,
+                    isBlocked = HealthSyncGating.isBlocked(endpoint, configured),
+                    blockedReason = HealthSyncGating.blockedReason(endpoint, configured),
+                    runDisabled = isRunDisabled(endpoint),
+                    onRun = { viewModel.run(endpoint) },
+                ) {
+                    EndpointInputs(
+                        endpoint = endpoint,
+                        deviceProviderOptions = deviceProviderOptions,
+                        selectedDeviceProvider = selectedDeviceProvider,
+                        onSelectDeviceProvider = viewModel::onSelectDeviceProvider,
+                        deleteConnectionIdInput = deleteConnectionIdInput,
+                        onDeleteConnectionIdInputChanged = viewModel::onDeleteConnectionIdInputChanged,
+                        deviceMetricsCodeOptions = deviceMetricsCodeOptions,
+                        selectedDeviceMetricsCode = selectedDeviceMetricsCode,
+                        onSelectDeviceMetricsCode = viewModel::onSelectDeviceMetricsCode,
+                        bodySystemOptions = bodySystemOptions,
+                        selectedBodySystemId = selectedBodySystemId,
+                        onSelectBodySystem = viewModel::onSelectBodySystem,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EndpointInputs(
+    endpoint: HealthSyncPlaygroundEndpoint,
+    deviceProviderOptions: List<com.bwell.common.models.domain.data.DeviceProvider>,
+    selectedDeviceProvider: com.bwell.common.models.domain.data.DeviceProvider?,
+    onSelectDeviceProvider: (com.bwell.common.models.domain.data.DeviceProvider) -> Unit,
+    deleteConnectionIdInput: String,
+    onDeleteConnectionIdInputChanged: (String) -> Unit,
+    deviceMetricsCodeOptions: List<PlaygroundCodeOption>,
+    selectedDeviceMetricsCode: String?,
+    onSelectDeviceMetricsCode: (String?) -> Unit,
+    bodySystemOptions: List<BodySystemOption>,
+    selectedBodySystemId: String?,
+    onSelectBodySystem: (String) -> Unit,
+) {
+    when (endpoint) {
+        HealthSyncPlaygroundEndpoint.GET_OAUTH_URL,
+        HealthSyncPlaygroundEndpoint.GET_DEVICE_PROVIDER_STATUS,
+        -> {
+            LabeledDropdown(
+                label = "Provider",
+                options = deviceProviderOptions,
+                selectedLabel = selectedDeviceProvider?.name,
+                displayText = { it.name },
+                onSelect = onSelectDeviceProvider,
+            )
+        }
+        HealthSyncPlaygroundEndpoint.DELETE_CONNECTION -> {
+            LabeledDropdown(
+                label = "Provider",
+                options = deviceProviderOptions,
+                selectedLabel = selectedDeviceProvider?.name,
+                displayText = { it.name },
+                onSelect = onSelectDeviceProvider,
+            )
+            OutlinedTextField(
+                value = deleteConnectionIdInput,
+                onValueChange = onDeleteConnectionIdInputChanged,
+                label = { Text("connectionId") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            )
+        }
+        HealthSyncPlaygroundEndpoint.GET_DEVICE_METRICS -> {
+            LabeledDropdown(
+                label = "Code",
+                options = deviceMetricsCodeOptions,
+                selectedLabel = deviceMetricsCodeOptions.firstOrNull { it.code == selectedDeviceMetricsCode }?.label,
+                displayText = { it.label },
+                onSelect = { onSelectDeviceMetricsCode(it.code) },
+                emptyHintText = "No codes available yet — sync some data first (Mobile Sync group above)",
+            )
+        }
+        HealthSyncPlaygroundEndpoint.GET_BODY_SYSTEM_SCORE -> {
+            LabeledDropdown(
+                label = "Body system",
+                options = bodySystemOptions,
+                selectedLabel = bodySystemOptions.firstOrNull { it.bodySystemId == selectedBodySystemId }?.label,
+                displayText = { it.label },
+                onSelect = { onSelectBodySystem(it.bodySystemId) },
+                emptyHintText = "No body systems available yet — a health score must be computed first",
+            )
+        }
+        else -> Unit
+    }
+}
+
+/** A read-only dropdown backed by a live options list - ported from healthsync-sample's SmartDropdown. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun <T> LabeledDropdown(
+    label: String,
+    options: List<T>,
+    selectedLabel: String?,
+    displayText: (T) -> String,
+    onSelect: (T) -> Unit,
+    emptyHintText: String = "Loading options…",
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = Modifier.padding(top = 8.dp),
+    ) {
+        OutlinedTextField(
+            value = selectedLabel ?: if (options.isEmpty()) emptyHintText else "Select…",
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(label) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.fillMaxWidth().menuAnchor(),
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(displayText(option)) },
+                    onClick = {
+                        onSelect(option)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundViewModel.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundViewModel.kt
@@ -1,5 +1,6 @@
 package com.bwell.sampleapp.activities.ui.healthsync
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bwell.common.models.domain.data.DeviceProvider
@@ -42,6 +43,8 @@ class HealthSyncPlaygroundViewModel(private val repository: HealthSyncRepository
         // Playground hardcodes "apple_health" for setupMobileSync/
         // getDeviceUserStatus - it is not a user-editable field.
         const val PLAYGROUND_CONNECTION_ID = "health_connect"
+
+        private const val TAG = "HealthSyncPlayground"
     }
 
     private val _results = MutableStateFlow<Map<HealthSyncPlaygroundEndpoint, PlaygroundCardState>>(emptyMap())
@@ -108,12 +111,14 @@ class HealthSyncPlaygroundViewModel(private val repository: HealthSyncRepository
             // Reachable before login (SDK not yet initialized) - BaseSdk's
             // accessors throw synchronously in that case, not a BWellResult
             // error, so this needs its own catch rather than relying on
-            // BWellResult.success(). Failures are logged silently here, same
-            // as Swift's attach() - the provider picker just stays empty and
-            // its dependent cards stay disabled (see isRunDisabled).
+            // BWellResult.success(). The provider picker just stays empty and
+            // its dependent cards stay disabled (see isRunDisabled) - but the
+            // exception itself is still logged, so a genuine misconfiguration
+            // is distinguishable from the expected pre-login case.
             val result = try {
                 repository.getDeviceProviders()
             } catch (e: Exception) {
+                Log.w(TAG, "loadDeviceProviderOptions failed", e)
                 return@launch
             }
             if (result is BWellResult.SingleResource && result.success()) {
@@ -132,6 +137,7 @@ class HealthSyncPlaygroundViewModel(private val repository: HealthSyncRepository
             val result = try {
                 repository.getDeviceMetricsGroups()
             } catch (e: Exception) {
+                Log.w(TAG, "loadDeviceMetricsCodeOptions failed", e)
                 return@launch
             }
             if (result is BWellResult.ResourceCollection && result.success()) {
@@ -153,6 +159,7 @@ class HealthSyncPlaygroundViewModel(private val repository: HealthSyncRepository
             val result = try {
                 repository.getHealthScore()
             } catch (e: Exception) {
+                Log.w(TAG, "loadBodySystemOptions failed", e)
                 return@launch
             }
             if (result is BWellResult.SingleResource && result.success()) {

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundViewModel.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundViewModel.kt
@@ -1,0 +1,254 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bwell.common.models.domain.data.DeviceProvider
+import com.bwell.common.models.responses.BWellResult
+import com.bwell.sampleapp.repository.HealthSyncRepository
+import com.google.gson.GsonBuilder
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/** Per-card result - each card runs and renders independently of the others. */
+sealed interface PlaygroundCardState {
+    data object Idle : PlaygroundCardState
+    data object Loading : PlaygroundCardState
+    data class Success(val raw: String) : PlaygroundCardState
+    data class Error(val message: String) : PlaygroundCardState
+}
+
+/** A dropdown option carrying a raw code + its display label - ported from Swift's PlaygroundCodeOption. */
+data class PlaygroundCodeOption(val code: String, val display: String?) {
+    val label: String get() = if (display != null) "$code - $display" else code
+}
+
+data class BodySystemOption(val bodySystemId: String, val title: String?) {
+    val label: String get() = title ?: bodySystemId
+}
+
+/**
+ * Ported from Swift's HealthSyncPlaygroundViewModel. Drives every card in
+ * [HealthSyncPlaygroundScreen]: dispatches a run, tracks per-card state, and
+ * lazily loads the 3 dynamic dropdowns (device providers, device-metrics
+ * codes, body systems) the same way Swift's `.task {}` modifiers do.
+ */
+class HealthSyncPlaygroundViewModel(private val repository: HealthSyncRepository) : ViewModel() {
+
+    companion object {
+        // Matches the internal healthsync-sample's convention for the
+        // on-device source's connection id. Hardcoded here, same as Swift's
+        // Playground hardcodes "apple_health" for setupMobileSync/
+        // getDeviceUserStatus - it is not a user-editable field.
+        const val PLAYGROUND_CONNECTION_ID = "health_connect"
+    }
+
+    private val _results = MutableStateFlow<Map<HealthSyncPlaygroundEndpoint, PlaygroundCardState>>(emptyMap())
+    val results: StateFlow<Map<HealthSyncPlaygroundEndpoint, PlaygroundCardState>> = _results.asStateFlow()
+
+    private val _configured = MutableStateFlow(repository.isHealthSyncConfigured())
+    val configured: StateFlow<Boolean> = _configured.asStateFlow()
+
+    private val _deviceProviderOptions = MutableStateFlow<List<DeviceProvider>>(emptyList())
+    val deviceProviderOptions: StateFlow<List<DeviceProvider>> = _deviceProviderOptions.asStateFlow()
+
+    private val _selectedDeviceProvider = MutableStateFlow<DeviceProvider?>(null)
+    val selectedDeviceProvider: StateFlow<DeviceProvider?> = _selectedDeviceProvider.asStateFlow()
+
+    // Only used by deleteConnection - auto-prefilled from the selected
+    // provider's slug, editable, distinct from PLAYGROUND_CONNECTION_ID.
+    private val _deleteConnectionIdInput = MutableStateFlow("")
+    val deleteConnectionIdInput: StateFlow<String> = _deleteConnectionIdInput.asStateFlow()
+
+    private val _deviceMetricsCodeOptions = MutableStateFlow<List<PlaygroundCodeOption>>(emptyList())
+    val deviceMetricsCodeOptions: StateFlow<List<PlaygroundCodeOption>> = _deviceMetricsCodeOptions.asStateFlow()
+
+    private val _selectedDeviceMetricsCode = MutableStateFlow<String?>(null)
+    val selectedDeviceMetricsCode: StateFlow<String?> = _selectedDeviceMetricsCode.asStateFlow()
+
+    private val _bodySystemOptions = MutableStateFlow<List<BodySystemOption>>(emptyList())
+    val bodySystemOptions: StateFlow<List<BodySystemOption>> = _bodySystemOptions.asStateFlow()
+
+    private val _selectedBodySystemId = MutableStateFlow<String?>(null)
+    val selectedBodySystemId: StateFlow<String?> = _selectedBodySystemId.asStateFlow()
+
+    private var attached = false
+    private val playgroundJson = GsonBuilder().setPrettyPrinting().create()
+
+    /** Idempotent - safe to call from every screen that hosts the Playground (direct or Dashboard tab). */
+    fun attach() {
+        if (attached) return
+        attached = true
+        _configured.value = repository.isHealthSyncConfigured()
+        loadDeviceProviderOptions()
+        loadDeviceMetricsCodeOptions()
+        loadBodySystemOptions()
+    }
+
+    fun onSelectDeviceProvider(provider: DeviceProvider) {
+        _selectedDeviceProvider.value = provider
+        _deleteConnectionIdInput.value = provider.slug
+    }
+
+    fun onDeleteConnectionIdInputChanged(value: String) {
+        _deleteConnectionIdInput.value = value
+    }
+
+    fun onSelectDeviceMetricsCode(code: String?) {
+        _selectedDeviceMetricsCode.value = code
+    }
+
+    fun onSelectBodySystem(bodySystemId: String) {
+        _selectedBodySystemId.value = bodySystemId
+    }
+
+    private fun loadDeviceProviderOptions() {
+        viewModelScope.launch {
+            // Reachable before login (SDK not yet initialized) - BaseSdk's
+            // accessors throw synchronously in that case, not a BWellResult
+            // error, so this needs its own catch rather than relying on
+            // BWellResult.success(). Failures are logged silently here, same
+            // as Swift's attach() - the provider picker just stays empty and
+            // its dependent cards stay disabled (see isRunDisabled).
+            val result = try {
+                repository.getDeviceProviders()
+            } catch (e: Exception) {
+                return@launch
+            }
+            if (result is BWellResult.SingleResource && result.success()) {
+                val providers = result.data?.providers.orEmpty()
+                _deviceProviderOptions.value = providers
+                if (_selectedDeviceProvider.value == null) {
+                    providers.firstOrNull()?.let(::onSelectDeviceProvider)
+                }
+            }
+        }
+    }
+
+    /** Dedupes getDeviceMetricsGroups() results by coding.code, sorted - mirrors Swift's loadDeviceMetricsCodeOptions. */
+    private fun loadDeviceMetricsCodeOptions() {
+        viewModelScope.launch {
+            val result = try {
+                repository.getDeviceMetricsGroups()
+            } catch (e: Exception) {
+                return@launch
+            }
+            if (result is BWellResult.ResourceCollection && result.success()) {
+                val options = result.data.orEmpty()
+                    .mapNotNull { it.coding?.code?.let { code -> PlaygroundCodeOption(code, it.coding?.display) } }
+                    .distinctBy { it.code }
+                    .sortedBy { it.code }
+                _deviceMetricsCodeOptions.value = options
+                if (_selectedDeviceMetricsCode.value != null && options.none { it.code == _selectedDeviceMetricsCode.value }) {
+                    _selectedDeviceMetricsCode.value = null
+                }
+            }
+        }
+    }
+
+    /** Sourced from getHealthScore()'s contributing body systems - mirrors Swift's loadBodySystemOptions. */
+    private fun loadBodySystemOptions() {
+        viewModelScope.launch {
+            val result = try {
+                repository.getHealthScore()
+            } catch (e: Exception) {
+                return@launch
+            }
+            if (result is BWellResult.SingleResource && result.success()) {
+                val options = result.data?.resource?.bodySystems.orEmpty()
+                    .mapNotNull { it.bodySystemId?.let { id -> BodySystemOption(id, it.title) } }
+                _bodySystemOptions.value = options
+                if (_selectedBodySystemId.value == null) {
+                    options.firstOrNull()?.let { _selectedBodySystemId.value = it.bodySystemId }
+                }
+            }
+        }
+    }
+
+    fun run(endpoint: HealthSyncPlaygroundEndpoint) {
+        val blockedReason = HealthSyncGating.blockedReason(endpoint, _configured.value)
+        if (blockedReason != null) {
+            _results.value = _results.value + (endpoint to PlaygroundCardState.Error(blockedReason))
+            return
+        }
+        _results.value = _results.value + (endpoint to PlaygroundCardState.Loading)
+        viewModelScope.launch {
+            val cardState = try {
+                runEndpoint(endpoint)
+            } catch (e: Exception) {
+                PlaygroundCardState.Error(e.message ?: "Unexpected exception")
+            }
+            _results.value = _results.value + (endpoint to cardState)
+        }
+    }
+
+    private suspend fun runEndpoint(endpoint: HealthSyncPlaygroundEndpoint): PlaygroundCardState = when (endpoint) {
+        HealthSyncPlaygroundEndpoint.CONNECT ->
+            repository.connect().toCardState { "connect() completed successfully." }
+        HealthSyncPlaygroundEndpoint.DISCONNECT ->
+            repository.disconnect().toCardState { "disconnect() completed successfully." }
+        HealthSyncPlaygroundEndpoint.REQUEST_PERMISSIONS ->
+            repository.requestPermissions().toCardState { "requestPermissions() completed successfully." }
+        HealthSyncPlaygroundEndpoint.SYNC ->
+            repository.sync().toCardState()
+        HealthSyncPlaygroundEndpoint.GET_CURRENT_USER -> {
+            val result = repository.currentUser()
+            val user = (result as? BWellResult.SingleResource)?.data
+            when {
+                !result.success() -> PlaygroundCardState.Error(result.error?.message() ?: "Unknown error")
+                user == null -> PlaygroundCardState.Success("No active session.")
+                else -> PlaygroundCardState.Success(
+                    "userId: ${user.userId}\norganizationId: ${user.organizationId}",
+                )
+            }
+        }
+        HealthSyncPlaygroundEndpoint.SETUP_MOBILE_SYNC ->
+            repository.setupMobileSync(PLAYGROUND_CONNECTION_ID).toCardState()
+        HealthSyncPlaygroundEndpoint.GET_DEVICE_USER_STATUS ->
+            repository.getDeviceUserStatus(PLAYGROUND_CONNECTION_ID).toCardState()
+        HealthSyncPlaygroundEndpoint.GET_OAUTH_URL ->
+            requireSelectedProvider()?.let { repository.getOauthUrl(it.slug).toCardState() }
+                ?: PlaygroundCardState.Error("Select a provider first")
+        HealthSyncPlaygroundEndpoint.GET_DEVICE_PROVIDER_STATUS ->
+            requireSelectedProvider()?.let { repository.getDeviceProviderStatus(it.slug).toCardState() }
+                ?: PlaygroundCardState.Error("Select a provider first")
+        HealthSyncPlaygroundEndpoint.GET_DEVICE_PROVIDERS ->
+            repository.getDeviceProviders().toCardState()
+        HealthSyncPlaygroundEndpoint.DELETE_CONNECTION -> {
+            val connectionId = _deleteConnectionIdInput.value.trim()
+            if (connectionId.isEmpty()) {
+                PlaygroundCardState.Error("Enter a connection id first")
+            } else {
+                val outcome = repository.deleteConnection(connectionId)
+                if (outcome.success()) {
+                    PlaygroundCardState.Success("deleteConnection() completed successfully.")
+                } else {
+                    PlaygroundCardState.Error(outcome.message())
+                }
+            }
+        }
+        HealthSyncPlaygroundEndpoint.GET_DEVICE_METRICS ->
+            repository.getDeviceMetrics(_selectedDeviceMetricsCode.value).toCardState()
+        HealthSyncPlaygroundEndpoint.GET_DEVICE_METRICS_GROUPS ->
+            repository.getDeviceMetricsGroups().toCardState()
+        HealthSyncPlaygroundEndpoint.GET_HEALTH_SCORE ->
+            repository.getHealthScore().toCardState()
+        HealthSyncPlaygroundEndpoint.GET_BODY_SYSTEM_SCORE ->
+            _selectedBodySystemId.value?.let { repository.getBodySystemScore(it).toCardState() }
+                ?: PlaygroundCardState.Error("Select a body system first")
+    }
+
+    private fun requireSelectedProvider(): DeviceProvider? = _selectedDeviceProvider.value
+
+    private fun BWellResult<*>.toCardState(onSuccess: (() -> String)? = null): PlaygroundCardState = when {
+        !success() -> PlaygroundCardState.Error(error?.message() ?: "Unknown error")
+        onSuccess != null -> PlaygroundCardState.Success(onSuccess())
+        this is BWellResult.SingleResource<*> -> PlaygroundCardState.Success(playgroundJson.toJson(data))
+        this is BWellResult.ResourceCollection<*> ->
+            PlaygroundCardState.Success(playgroundJson.toJson(mapOf("pagingInfo" to pagingInfo, "data" to data)))
+        this is BWellResult.SearchResults<*> ->
+            PlaygroundCardState.Success(playgroundJson.toJson(mapOf("pagingInfo" to pagingInfo, "data" to data)))
+        else -> PlaygroundCardState.Success(playgroundJson.toJson(this))
+    }
+}

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundViewModel.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundViewModel.kt
@@ -1,9 +1,11 @@
 package com.bwell.sampleapp.activities.ui.healthsync
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bwell.common.models.domain.data.DeviceProvider
+import com.bwell.common.models.domain.data.DeviceProviderList
+import com.bwell.common.models.domain.healthdata.healthsummary.devicemetrics.DeviceMetricsGroup
+import com.bwell.common.models.domain.healthdata.healthsummary.healthscore.HealthScoreResult
 import com.bwell.common.models.responses.BWellResult
 import com.bwell.sampleapp.repository.HealthSyncRepository
 import com.google.gson.GsonBuilder
@@ -89,7 +91,20 @@ class HealthSyncPlaygroundViewModel(private val repository: HealthSyncRepository
         loadBodySystemOptions()
     }
 
-    fun onSelectDeviceProvider(provider: DeviceProvider) {
+    /** For GET_OAUTH_URL/GET_DEVICE_PROVIDER_STATUS - selection only, never touches deleteConnectionIdInput. */
+    fun onSelectDeviceProviderForLookup(provider: DeviceProvider) {
+        _selectedDeviceProvider.value = provider
+    }
+
+    /**
+     * For DELETE_CONNECTION only - prefills the id field from the selected
+     * provider's slug. Kept separate from [onSelectDeviceProviderForLookup]:
+     * all 3 provider dropdowns previously shared one callback that always
+     * overwrote deleteConnectionIdInput, silently discarding a manually
+     * edited value whenever a provider was (re-)selected on either of the
+     * two unrelated lookup cards.
+     */
+    fun onSelectDeviceProviderForDelete(provider: DeviceProvider) {
         _selectedDeviceProvider.value = provider
         _deleteConnectionIdInput.value = provider.slug
     }
@@ -108,24 +123,17 @@ class HealthSyncPlaygroundViewModel(private val repository: HealthSyncRepository
 
     private fun loadDeviceProviderOptions() {
         viewModelScope.launch {
-            // Reachable before login (SDK not yet initialized) - BaseSdk's
-            // accessors throw synchronously in that case, not a BWellResult
-            // error, so this needs its own catch rather than relying on
-            // BWellResult.success(). The provider picker just stays empty and
-            // its dependent cards stay disabled (see isRunDisabled) - but the
-            // exception itself is still logged, so a genuine misconfiguration
-            // is distinguishable from the expected pre-login case.
-            val result = try {
+            // Reachable before login - see guardedCall's doc. The provider
+            // picker just stays empty and its dependent cards stay disabled
+            // (see isRunDisabled) on failure.
+            val result = guardedCall<BWellResult<DeviceProviderList>?>(TAG, "loadDeviceProviderOptions", null) {
                 repository.getDeviceProviders()
-            } catch (e: Exception) {
-                Log.w(TAG, "loadDeviceProviderOptions failed", e)
-                return@launch
-            }
+            } ?: return@launch
             if (result is BWellResult.SingleResource && result.success()) {
                 val providers = result.data?.providers.orEmpty()
                 _deviceProviderOptions.value = providers
                 if (_selectedDeviceProvider.value == null) {
-                    providers.firstOrNull()?.let(::onSelectDeviceProvider)
+                    providers.firstOrNull()?.let(::onSelectDeviceProviderForDelete)
                 }
             }
         }
@@ -134,12 +142,9 @@ class HealthSyncPlaygroundViewModel(private val repository: HealthSyncRepository
     /** Dedupes getDeviceMetricsGroups() results by coding.code, sorted - mirrors Swift's loadDeviceMetricsCodeOptions. */
     private fun loadDeviceMetricsCodeOptions() {
         viewModelScope.launch {
-            val result = try {
+            val result = guardedCall<BWellResult<DeviceMetricsGroup>?>(TAG, "loadDeviceMetricsCodeOptions", null) {
                 repository.getDeviceMetricsGroups()
-            } catch (e: Exception) {
-                Log.w(TAG, "loadDeviceMetricsCodeOptions failed", e)
-                return@launch
-            }
+            } ?: return@launch
             if (result is BWellResult.ResourceCollection && result.success()) {
                 val options = result.data.orEmpty()
                     .mapNotNull { it.coding?.code?.let { code -> PlaygroundCodeOption(code, it.coding?.display) } }
@@ -156,12 +161,9 @@ class HealthSyncPlaygroundViewModel(private val repository: HealthSyncRepository
     /** Sourced from getHealthScore()'s contributing body systems - mirrors Swift's loadBodySystemOptions. */
     private fun loadBodySystemOptions() {
         viewModelScope.launch {
-            val result = try {
+            val result = guardedCall<BWellResult<HealthScoreResult>?>(TAG, "loadBodySystemOptions", null) {
                 repository.getHealthScore()
-            } catch (e: Exception) {
-                Log.w(TAG, "loadBodySystemOptions failed", e)
-                return@launch
-            }
+            } ?: return@launch
             if (result is BWellResult.SingleResource && result.success()) {
                 val options = result.data?.resource?.bodySystems.orEmpty()
                     .mapNotNull { it.bodySystemId?.let { id -> BodySystemOption(id, it.title) } }
@@ -187,6 +189,15 @@ class HealthSyncPlaygroundViewModel(private val repository: HealthSyncRepository
                 PlaygroundCardState.Error(e.message ?: "Unexpected exception")
             }
             _results.value = _results.value + (endpoint to cardState)
+
+            // GET_DEVICE_METRICS/GET_BODY_SYSTEM_SCORE's own copy promises
+            // their dropdowns populate "each time this card appears" - a
+            // successful sync is the actual real-world trigger for that data
+            // existing, so refresh both here rather than only once at attach().
+            if (endpoint == HealthSyncPlaygroundEndpoint.SYNC && cardState is PlaygroundCardState.Success) {
+                loadDeviceMetricsCodeOptions()
+                loadBodySystemOptions()
+            }
         }
     }
 

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncRootScreen.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncRootScreen.kt
@@ -1,0 +1,29 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * Single entry point for the Health Sync feature - ported from Swift's
+ * HealthSyncPlaygroundRootView. Branches on
+ * [com.bwell.healthsync.BWellHealthSync.isConfigured] (read eagerly at
+ * [HealthSyncPlaygroundViewModel] construction, not lazily, so this decision
+ * never blocks on attach()): the Dashboard when an on-device adapter is
+ * configured, the raw Playground directly otherwise.
+ */
+@Composable
+fun HealthSyncRootScreen(
+    playgroundViewModel: HealthSyncPlaygroundViewModel,
+    dashboardViewModel: HealthSyncDashboardViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val configured by playgroundViewModel.configured.collectAsStateWithLifecycle()
+    if (configured) {
+        HealthSyncDashboardScreen(dashboardViewModel, playgroundViewModel, modifier.fillMaxSize())
+    } else {
+        HealthSyncPlaygroundScreen(playgroundViewModel, modifier.fillMaxSize())
+    }
+}

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/PlaygroundCard.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/activities/ui/healthsync/PlaygroundCard.kt
@@ -1,0 +1,219 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+/**
+ * One endpoint's card - ported from Swift's PlaygroundCard.swift: title +
+ * optional info button/sheet, Run button (or "Blocked" when [isBlocked],
+ * disabled either way), copy-to-clipboard on a successful result, and
+ * [content] as a slot for endpoint-specific inputs (provider/code/body
+ * system pickers).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlaygroundCard(
+    endpoint: HealthSyncPlaygroundEndpoint,
+    state: PlaygroundCardState,
+    isBlocked: Boolean,
+    blockedReason: String?,
+    runDisabled: Boolean,
+    onRun: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit = {},
+) {
+    var showInfoSheet by remember { mutableStateOf(false) }
+    val hasInfo = endpoint.documentationUrl != null || endpoint.parameterInfo != null
+
+    Card(modifier = modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    endpoint.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                if (hasInfo) {
+                    IconButton(onClick = { showInfoSheet = true }) {
+                        Icon(
+                            Icons.Filled.Info,
+                            contentDescription = "More info about ${endpoint.title}",
+                            tint = MaterialTheme.colorScheme.secondary,
+                        )
+                    }
+                }
+                if (state is PlaygroundCardState.Success) {
+                    CopyButton(text = state.raw)
+                }
+                when (state) {
+                    is PlaygroundCardState.Loading ->
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                    else ->
+                        Button(onClick = onRun, enabled = !isBlocked && !runDisabled) {
+                            Text(if (isBlocked) "Blocked" else "Run")
+                        }
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+            Text(
+                endpoint.explanation,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            if (blockedReason != null) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    blockedReason,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.tertiary,
+                )
+            }
+
+            content()
+
+            when (state) {
+                is PlaygroundCardState.Success -> {
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        state.raw,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.fillMaxWidth()
+                            .heightIn(max = 220.dp)
+                            .verticalScroll(rememberScrollState()),
+                    )
+                }
+                is PlaygroundCardState.Error -> {
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        state.message,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                else -> Unit
+            }
+        }
+    }
+
+    if (showInfoSheet) {
+        val sheetState = rememberModalBottomSheetState()
+        val context = LocalContext.current
+        ModalBottomSheet(onDismissRequest = { showInfoSheet = false }, sheetState = sheetState) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Text(endpoint.title, style = MaterialTheme.typography.titleLarge)
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    endpoint.documentationSummary ?: endpoint.explanation,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                endpoint.parameterInfo?.let { info ->
+                    Spacer(Modifier.height(16.dp))
+                    Text("Parameters", style = MaterialTheme.typography.titleSmall)
+                    Spacer(Modifier.height(4.dp))
+                    Text(info, style = MaterialTheme.typography.bodySmall)
+                }
+                endpoint.documentationUrl?.let { url ->
+                    Spacer(Modifier.height(16.dp))
+                    OutlinedButton(
+                        onClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url))) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text("More info on the doc page")
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
+            }
+        }
+    }
+}
+
+/** Swaps to a checkmark for 1.2s after copying - mirrors Swift's PlaygroundCard copy affordance. */
+@Composable
+private fun CopyButton(text: String) {
+    val clipboard = LocalClipboardManager.current
+    var justCopied by remember { mutableStateOf(false) }
+
+    LaunchedEffect(justCopied) {
+        if (justCopied) {
+            delay(1200)
+            justCopied = false
+        }
+    }
+
+    IconButton(onClick = {
+        clipboard.setText(AnnotatedString(text))
+        justCopied = true
+    }) {
+        Icon(
+            if (justCopied) Icons.Filled.Check else Icons.Filled.ContentCopy,
+            contentDescription = "Copy output",
+            tint = MaterialTheme.colorScheme.secondary,
+        )
+    }
+}
+
+/** Info banner for the Read Data group - ported from Swift's PlaygroundNoteBanner. */
+@Composable
+fun PlaygroundNoteBanner(text: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.Top) {
+            Icon(
+                Icons.Filled.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.padding(top = 2.dp),
+            )
+            Spacer(Modifier.padding(horizontal = 4.dp))
+            Text(
+                text,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/HealthSyncRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/HealthSyncRepository.kt
@@ -35,62 +35,66 @@ import java.time.temporal.ChronoUnit
  * which throws IllegalStateException if
  * [com.bwell.healthsync.BWellHealthSync.isConfigured] is false - callers
  * must check that first (see HealthSyncGating).
+ *
+ * Open (and every member open) so tests can subclass with a fake instead of
+ * touching the real static [BWellSdk] singleton - no DI framework exists in
+ * this app to inject an interface instead.
  */
-class HealthSyncRepository {
+open class HealthSyncRepository {
 
     // 30-day window - matches Swift's Playground `sync` card and Dashboard's
     // "Sync with b.well" action.
     private val syncWindowDays = 30L
 
-    suspend fun connect(): BWellResult<Unit> = BWellSdk.healthSync.connect()
+    open suspend fun connect(): BWellResult<Unit> = BWellSdk.healthSync.connect()
 
-    suspend fun disconnect(): BWellResult<Unit> = BWellSdk.healthSync.disconnect()
+    open suspend fun disconnect(): BWellResult<Unit> = BWellSdk.healthSync.disconnect()
 
-    suspend fun requestPermissions(): BWellResult<Unit> =
+    open suspend fun requestPermissions(): BWellResult<Unit> =
         BWellSdk.healthSync.requestPermissions(HealthDataType.entries.toSet())
 
-    suspend fun sync(): BWellResult<SyncCounts> {
+    open suspend fun sync(): BWellResult<SyncCounts> {
         val now = Instant.now()
         val window = DateRange(from = now.minus(syncWindowDays, ChronoUnit.DAYS), to = now)
         return BWellSdk.healthSync.sync(HealthDataType.entries.toSet(), window)
     }
 
-    suspend fun currentUser(): BWellResult<HealthSyncUser?> = BWellSdk.healthSync.currentUser()
+    open suspend fun currentUser(): BWellResult<HealthSyncUser?> = BWellSdk.healthSync.currentUser()
 
-    suspend fun endSession(): BWellResult<Unit> = BWellSdk.healthSync.endSession()
+    open suspend fun endSession(): BWellResult<Unit> = BWellSdk.healthSync.endSession()
 
-    suspend fun setupMobileSync(connectionId: String): BWellResult<MobileSyncCredentials> =
+    open suspend fun setupMobileSync(connectionId: String): BWellResult<MobileSyncCredentials> =
         BWellSdk.device.setupMobileSync(connectionId)
 
-    suspend fun getDeviceUserStatus(connectionId: String): BWellResult<DeviceUserStatus> =
+    open suspend fun getDeviceUserStatus(connectionId: String): BWellResult<DeviceUserStatus> =
         BWellSdk.device.getDeviceUserStatus(connectionId)
 
-    suspend fun getOauthUrl(providerSlug: String): BWellResult<String> =
+    open suspend fun getOauthUrl(providerSlug: String): BWellResult<String> =
         BWellSdk.connections.getOauthUrl(providerSlug)
 
-    suspend fun getDeviceProviderStatus(connectionId: String): BWellResult<DeviceProviderStatus> =
+    open suspend fun getDeviceProviderStatus(connectionId: String): BWellResult<DeviceProviderStatus> =
         BWellSdk.device.getDeviceProviderStatus(connectionId)
 
-    suspend fun getDeviceProviders(): BWellResult<DeviceProviderList> =
+    open suspend fun getDeviceProviders(): BWellResult<DeviceProviderList> =
         BWellSdk.device.getDeviceProviders()
 
-    suspend fun deleteConnection(connectionId: String): OperationOutcome =
+    open suspend fun deleteConnection(connectionId: String): OperationOutcome =
         BWellSdk.connections.deleteConnection(connectionId)
 
-    suspend fun getDeviceMetrics(groupCode: String?): BWellResult<Observation> =
+    open suspend fun getDeviceMetrics(groupCode: String?): BWellResult<Observation> =
         BWellSdk.health.getDeviceMetrics(
             DeviceMetricsQueryRequest.Builder()
                 .apply { groupCode?.let { groupCode(listOf(Coding(code = it))) } }
                 .build(),
         )
 
-    suspend fun getDeviceMetricsGroups(): BWellResult<DeviceMetricsGroup> =
+    open suspend fun getDeviceMetricsGroups(): BWellResult<DeviceMetricsGroup> =
         BWellSdk.health.getDeviceMetricsGroups(DeviceMetricsGroupsRequest.Builder().build())
 
-    suspend fun getHealthScore(): BWellResult<HealthScoreResult> = BWellSdk.health.getHealthScore()
+    open suspend fun getHealthScore(): BWellResult<HealthScoreResult> = BWellSdk.health.getHealthScore()
 
-    suspend fun getBodySystemScore(bodySystemId: String): BWellResult<BodySystemScoreResult> =
+    open suspend fun getBodySystemScore(bodySystemId: String): BWellResult<BodySystemScoreResult> =
         BWellSdk.health.getBodySystemScore(bodySystemId)
 
-    fun isHealthSyncConfigured(): Boolean = BWellHealthSync.isConfigured
+    open fun isHealthSyncConfigured(): Boolean = BWellHealthSync.isConfigured
 }

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/HealthSyncRepository.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/repository/HealthSyncRepository.kt
@@ -1,0 +1,96 @@
+package com.bwell.sampleapp.repository
+
+import com.bwell.common.models.domain.common.Coding
+import com.bwell.common.models.domain.data.DeviceProviderList
+import com.bwell.common.models.domain.data.DeviceProviderStatus
+import com.bwell.common.models.domain.data.DeviceUserStatus
+import com.bwell.common.models.domain.data.MobileSyncCredentials
+import com.bwell.common.models.domain.healthdata.common.observation.Observation
+import com.bwell.common.models.domain.healthdata.healthsummary.devicemetrics.DeviceMetricsGroup
+import com.bwell.common.models.responses.BWellResult
+import com.bwell.common.models.responses.OperationOutcome
+import com.bwell.common.models.domain.healthdata.healthsummary.healthscore.BodySystemScoreResult
+import com.bwell.common.models.domain.healthdata.healthsummary.healthscore.HealthScoreResult
+import com.bwell.healthdata.healthsummary.requests.devicemetrics.DeviceMetricsGroupsRequest
+import com.bwell.healthdata.healthsummary.requests.devicemetrics.DeviceMetricsQueryRequest
+import com.bwell.healthsync.BWellHealthSync
+import com.bwell.healthsync.healthSync
+import com.bwell.healthsync.model.DateRange
+import com.bwell.healthsync.model.HealthDataType
+import com.bwell.healthsync.model.HealthSyncUser
+import com.bwell.healthsync.model.SyncCounts
+import com.bwell.sampleapp.singletons.BWellSdk
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * Wraps every b.well SDK call the Health Sync Playground/Dashboard uses -
+ * matches the app's existing per-feature repository convention (see
+ * InsuranceRepository). Deliberately thin: each method is a single SDK call,
+ * no business logic, so the ViewModel stays the only place gating/state
+ * decisions happen.
+ *
+ * The Mobile Sync methods here (connect/disconnect/requestPermissions/sync/
+ * currentUser) all go through [com.bwell.healthsync.HealthSyncManager],
+ * which throws IllegalStateException if
+ * [com.bwell.healthsync.BWellHealthSync.isConfigured] is false - callers
+ * must check that first (see HealthSyncGating).
+ */
+class HealthSyncRepository {
+
+    // 30-day window - matches Swift's Playground `sync` card and Dashboard's
+    // "Sync with b.well" action.
+    private val syncWindowDays = 30L
+
+    suspend fun connect(): BWellResult<Unit> = BWellSdk.healthSync.connect()
+
+    suspend fun disconnect(): BWellResult<Unit> = BWellSdk.healthSync.disconnect()
+
+    suspend fun requestPermissions(): BWellResult<Unit> =
+        BWellSdk.healthSync.requestPermissions(HealthDataType.entries.toSet())
+
+    suspend fun sync(): BWellResult<SyncCounts> {
+        val now = Instant.now()
+        val window = DateRange(from = now.minus(syncWindowDays, ChronoUnit.DAYS), to = now)
+        return BWellSdk.healthSync.sync(HealthDataType.entries.toSet(), window)
+    }
+
+    suspend fun currentUser(): BWellResult<HealthSyncUser?> = BWellSdk.healthSync.currentUser()
+
+    suspend fun endSession(): BWellResult<Unit> = BWellSdk.healthSync.endSession()
+
+    suspend fun setupMobileSync(connectionId: String): BWellResult<MobileSyncCredentials> =
+        BWellSdk.device.setupMobileSync(connectionId)
+
+    suspend fun getDeviceUserStatus(connectionId: String): BWellResult<DeviceUserStatus> =
+        BWellSdk.device.getDeviceUserStatus(connectionId)
+
+    suspend fun getOauthUrl(providerSlug: String): BWellResult<String> =
+        BWellSdk.connections.getOauthUrl(providerSlug)
+
+    suspend fun getDeviceProviderStatus(connectionId: String): BWellResult<DeviceProviderStatus> =
+        BWellSdk.device.getDeviceProviderStatus(connectionId)
+
+    suspend fun getDeviceProviders(): BWellResult<DeviceProviderList> =
+        BWellSdk.device.getDeviceProviders()
+
+    suspend fun deleteConnection(connectionId: String): OperationOutcome =
+        BWellSdk.connections.deleteConnection(connectionId)
+
+    suspend fun getDeviceMetrics(groupCode: String?): BWellResult<Observation> =
+        BWellSdk.health.getDeviceMetrics(
+            DeviceMetricsQueryRequest.Builder()
+                .apply { groupCode?.let { groupCode(listOf(Coding(code = it))) } }
+                .build(),
+        )
+
+    suspend fun getDeviceMetricsGroups(): BWellResult<DeviceMetricsGroup> =
+        BWellSdk.health.getDeviceMetricsGroups(DeviceMetricsGroupsRequest.Builder().build())
+
+    suspend fun getHealthScore(): BWellResult<HealthScoreResult> = BWellSdk.health.getHealthScore()
+
+    suspend fun getBodySystemScore(bodySystemId: String): BWellResult<BodySystemScoreResult> =
+        BWellSdk.health.getBodySystemScore(bodySystemId)
+
+    fun isHealthSyncConfigured(): Boolean = BWellHealthSync.isConfigured
+}

--- a/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/viewmodel/HealthSyncViewModelFactory.kt
+++ b/bwell-kotlin-android/app/src/main/java/com/bwell/sampleapp/viewmodel/HealthSyncViewModelFactory.kt
@@ -1,0 +1,21 @@
+package com.bwell.sampleapp.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.bwell.sampleapp.activities.ui.healthsync.HealthSyncDashboardViewModel
+import com.bwell.sampleapp.activities.ui.healthsync.HealthSyncPlaygroundViewModel
+import com.bwell.sampleapp.repository.HealthSyncRepository
+
+class HealthSyncViewModelFactory(private val repository: HealthSyncRepository) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return when {
+            modelClass.isAssignableFrom(HealthSyncPlaygroundViewModel::class.java) -> {
+                HealthSyncPlaygroundViewModel(repository) as T
+            }
+            modelClass.isAssignableFrom(HealthSyncDashboardViewModel::class.java) -> {
+                HealthSyncDashboardViewModel(repository) as T
+            }
+            else -> throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}

--- a/bwell-kotlin-android/app/src/main/res/menu/activity_navigation_drawer.xml
+++ b/bwell-kotlin-android/app/src/main/res/menu/activity_navigation_drawer.xml
@@ -42,5 +42,9 @@
             android:id="@+id/nav_medicines"
             android:icon="@drawable/medicine_logo"
             android:title="@string/menu_medicines" />
+        <item
+            android:id="@+id/nav_health_sync"
+            android:icon="@drawable/icon_hurt_summary"
+            android:title="@string/menu_health_sync" />
     </group>
 </menu>

--- a/bwell-kotlin-android/app/src/main/res/navigation/mobile_navigation.xml
+++ b/bwell-kotlin-android/app/src/main/res/navigation/mobile_navigation.xml
@@ -58,4 +58,9 @@
         android:name="com.bwell.sampleapp.activities.ui.profile.ProfileFragment"
         android:label="@string/menu_profile"
         tools:layout="@layout/fragment_profile" />
+
+    <fragment
+        android:id="@+id/nav_health_sync"
+        android:name="com.bwell.sampleapp.activities.ui.healthsync.HealthSyncPlaygroundFragment"
+        android:label="@string/menu_health_sync" />
 </navigation>

--- a/bwell-kotlin-android/app/src/main/res/values/strings.xml
+++ b/bwell-kotlin-android/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="menu_settings">Settings</string>
     <string name="menu_labs">Labs</string>
     <string name="menu_medicines">Medicines</string>
+    <string name="menu_health_sync">Health Sync</string>
     <string name="title_activity_navigation">NavigationActivity</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>

--- a/bwell-kotlin-android/app/src/test/java/com/bwell/sampleapp/activities/ui/healthsync/FakeHealthSyncRepository.kt
+++ b/bwell-kotlin-android/app/src/test/java/com/bwell/sampleapp/activities/ui/healthsync/FakeHealthSyncRepository.kt
@@ -1,0 +1,34 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import com.bwell.common.models.domain.data.DeviceProviderList
+import com.bwell.common.models.responses.BWellResult
+import com.bwell.sampleapp.repository.HealthSyncRepository
+
+/**
+ * Test double for [HealthSyncRepository] - records call counts so tests can
+ * assert a gated endpoint never reaches the repository, and returns canned
+ * results so dispatch/error-mapping can be tested without a real [BWellSdk].
+ */
+class FakeHealthSyncRepository(
+    private var configured: Boolean = false,
+) : HealthSyncRepository() {
+
+    var connectCallCount = 0
+    var connectResult: BWellResult<Unit> = BWellResult.SingleResource(data = Unit, error = null)
+
+    var getDeviceProvidersCallCount = 0
+    var deviceProvidersResult: BWellResult<DeviceProviderList> =
+        BWellResult.SingleResource(data = DeviceProviderList(providers = emptyList()), error = null)
+
+    override fun isHealthSyncConfigured(): Boolean = configured
+
+    override suspend fun connect(): BWellResult<Unit> {
+        connectCallCount++
+        return connectResult
+    }
+
+    override suspend fun getDeviceProviders(): BWellResult<DeviceProviderList> {
+        getDeviceProvidersCallCount++
+        return deviceProvidersResult
+    }
+}

--- a/bwell-kotlin-android/app/src/test/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncGatingTest.kt
+++ b/bwell-kotlin-android/app/src/test/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncGatingTest.kt
@@ -1,0 +1,69 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HealthSyncGatingTest {
+
+    private val gatedEndpoints = setOf(
+        HealthSyncPlaygroundEndpoint.CONNECT,
+        HealthSyncPlaygroundEndpoint.DISCONNECT,
+        HealthSyncPlaygroundEndpoint.REQUEST_PERMISSIONS,
+        HealthSyncPlaygroundEndpoint.SYNC,
+        HealthSyncPlaygroundEndpoint.GET_CURRENT_USER,
+    )
+
+    @Test
+    fun `gated endpoints are blocked when not configured`() {
+        gatedEndpoints.forEach { endpoint ->
+            assertTrue(
+                "$endpoint should be blocked when not configured",
+                HealthSyncGating.isBlocked(endpoint, configured = false),
+            )
+        }
+    }
+
+    @Test
+    fun `gated endpoints are not blocked when configured`() {
+        gatedEndpoints.forEach { endpoint ->
+            assertFalse(
+                "$endpoint should not be blocked when configured",
+                HealthSyncGating.isBlocked(endpoint, configured = true),
+            )
+        }
+    }
+
+    @Test
+    fun `non-gated endpoints are never blocked, configured or not`() {
+        val nonGated = HealthSyncPlaygroundEndpoint.entries.toSet() - gatedEndpoints
+        nonGated.forEach { endpoint ->
+            assertFalse(HealthSyncGating.isBlocked(endpoint, configured = false))
+            assertFalse(HealthSyncGating.isBlocked(endpoint, configured = true))
+        }
+    }
+
+    @Test
+    fun `blockedReason returns the locked copy exactly when blocked`() {
+        assertEquals(
+            HEALTH_SYNC_NOT_CONFIGURED_MESSAGE,
+            HealthSyncGating.blockedReason(HealthSyncPlaygroundEndpoint.SYNC, configured = false),
+        )
+    }
+
+    @Test
+    fun `blockedReason is null when not blocked`() {
+        assertNull(HealthSyncGating.blockedReason(HealthSyncPlaygroundEndpoint.SYNC, configured = true))
+        assertNull(HealthSyncGating.blockedReason(HealthSyncPlaygroundEndpoint.GET_DEVICE_PROVIDERS, configured = false))
+    }
+
+    @Test
+    fun `exactly the 5 healthSync-backed Mobile Sync endpoints are gated`() {
+        val actuallyGated = HealthSyncPlaygroundEndpoint.entries
+            .filter { HealthSyncGating.isBlocked(it, configured = false) }
+            .toSet()
+        assertEquals(gatedEndpoints, actuallyGated)
+    }
+}

--- a/bwell-kotlin-android/app/src/test/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundViewModelTest.kt
+++ b/bwell-kotlin-android/app/src/test/java/com/bwell/sampleapp/activities/ui/healthsync/HealthSyncPlaygroundViewModelTest.kt
@@ -1,0 +1,82 @@
+package com.bwell.sampleapp.activities.ui.healthsync
+
+import com.bwell.common.models.responses.BWellResult
+import com.bwell.common.models.responses.error.BWellError
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HealthSyncPlaygroundViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        kotlinx.coroutines.Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        kotlinx.coroutines.Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `run does not call the repository for a blocked endpoint`() = runTest(dispatcher) {
+        val repository = FakeHealthSyncRepository(configured = false)
+        val viewModel = HealthSyncPlaygroundViewModel(repository)
+
+        viewModel.run(HealthSyncPlaygroundEndpoint.CONNECT)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(0, repository.connectCallCount)
+        assertEquals(
+            PlaygroundCardState.Error(HEALTH_SYNC_NOT_CONFIGURED_MESSAGE),
+            viewModel.results.value[HealthSyncPlaygroundEndpoint.CONNECT],
+        )
+    }
+
+    @Test
+    fun `run dispatches to the repository for a gated endpoint once configured`() = runTest(dispatcher) {
+        val repository = FakeHealthSyncRepository(configured = true)
+        val viewModel = HealthSyncPlaygroundViewModel(repository)
+
+        viewModel.run(HealthSyncPlaygroundEndpoint.CONNECT)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, repository.connectCallCount)
+        assertTrue(viewModel.results.value[HealthSyncPlaygroundEndpoint.CONNECT] is PlaygroundCardState.Success)
+    }
+
+    @Test
+    fun `run dispatches to the repository for a non-gated endpoint regardless of configuration`() = runTest(dispatcher) {
+        val repository = FakeHealthSyncRepository(configured = false)
+        val viewModel = HealthSyncPlaygroundViewModel(repository)
+
+        viewModel.run(HealthSyncPlaygroundEndpoint.GET_DEVICE_PROVIDERS)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1, repository.getDeviceProvidersCallCount)
+        assertTrue(viewModel.results.value[HealthSyncPlaygroundEndpoint.GET_DEVICE_PROVIDERS] is PlaygroundCardState.Success)
+    }
+
+    @Test
+    fun `run surfaces a repository error as an Error card state`() = runTest(dispatcher) {
+        val repository = FakeHealthSyncRepository(configured = false).apply {
+            deviceProvidersResult = BWellResult.SingleResource(data = null, error = BWellError(Exception("boom")))
+        }
+        val viewModel = HealthSyncPlaygroundViewModel(repository)
+
+        viewModel.run(HealthSyncPlaygroundEndpoint.GET_DEVICE_PROVIDERS)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.results.value[HealthSyncPlaygroundEndpoint.GET_DEVICE_PROVIDERS] is PlaygroundCardState.Error)
+    }
+}

--- a/bwell-kotlin-android/healthsync-local.app.gradle.kts.example
+++ b/bwell-kotlin-android/healthsync-local.app.gradle.kts.example
@@ -1,0 +1,30 @@
+// Health Sync on-device adapter - LOCAL TEST OVERLAY (app half).
+//
+// This is a TEMPLATE. To use it:
+//   1. cp healthsync-local.app.gradle.kts.example healthsync-local.app.gradle.kts
+//   2. cp -r app/src/healthSyncNeutral app/src/healthSyncLocal
+//      then, in the copy, replace HealthSyncAdapterBridge's no-op bodies
+//      with real calls into
+//      com.bwell.healthsync.adapter.aggregator.AggregatorHealthSource (see
+//      bwell-sdk-kotlin's healthsync-sample MainActivity.kt for the full
+//      pattern, including its permission-launcher wiring), and replace
+//      AndroidManifest.xml with the adapter's real manifest requirements
+//      (Health Connect <queries>, permissions-rationale intent-filter).
+//   3. Pair with healthsync-local.settings.gradle.kts (see its .example).
+//
+// Both halves are gitignored - `app/build.gradle.kts` only applies this
+// file, and only compiles/merges `src/healthSyncLocal`, if they exist. A
+// fresh clone with neither present builds with zero vendor dependencies.
+//
+// This file only needs the dependency line: the source-set and manifest
+// swap already live in the committed app/build.gradle.kts, since scripts
+// applied via apply(from=...) don't get AGP's precompiled `android { }`
+// type-safe accessors.
+
+dependencies {
+    // The published adapter - resolvable once healthsync-local.settings.gradle.kts's
+    // two repositories are also in place. Pin to whatever version you're
+    // testing against; keep it in sync with the bwell-sdk-kotlin-healthsync
+    // version declared in the committed app/build.gradle.kts.
+    "implementation"("com.bwell:bwell-sdk-kotlin-healthsync-adapter-aggregator:1.20.0")
+}

--- a/bwell-kotlin-android/healthsync-local.settings.gradle.kts.example
+++ b/bwell-kotlin-android/healthsync-local.settings.gradle.kts.example
@@ -1,0 +1,59 @@
+// Health Sync on-device adapter - LOCAL TEST OVERLAY (settings half).
+//
+// This is a TEMPLATE. To use it:
+//   cp healthsync-local.settings.gradle.kts.example healthsync-local.settings.gradle.kts
+// then fill in real credentials below. The real file is gitignored -
+// `settings.gradle.kts` only applies it if it exists, so a fresh clone with
+// no local overlay never sees a vendor or gated repository at all.
+//
+// Pair this with healthsync-local.app.gradle.kts (see its own .example) -
+// that half adds the actual adapter dependency; this half adds the two
+// repositories needed to resolve it and its vendor transitive dependencies.
+//
+// Simulates exactly how a real paying customer integrates the adapter -
+// nothing here is b.well-internal tooling.
+
+import org.gradle.api.credentials.HttpHeaderCredentials
+import org.gradle.authentication.http.HttpHeaderAuthentication
+
+dependencyResolutionManagement {
+    repositories {
+        // The adapter's own artifact. Published separately from the rest of
+        // the SDK (a different JFrog org than bwell-sdk-kotlin/-healthsync,
+        // which live on Nexus) - confirmed via the adapter's own published
+        // POM, anonymous 200.
+        maven {
+            name = "bwellPublicMavenReleases"
+            url = uri("https://artifacts.bwell.com/artifactory/public-maven-releases")
+        }
+
+        // The gated vendor repo the adapter's POM declares its
+        // com.validic.mobile:* runtime dependencies against (confirmed 401
+        // anonymous - credentials are mandatory, not optional). Routed
+        // through b.well's own Artifactory proxy (CIE-8240), content-filtered
+        // so it is NEVER consulted for anything outside these two groups.
+        //
+        // JFROG_READ_TOKEN is a JFrog reference/identity token, not a
+        // username+password pair - confirmed by testing both ways against
+        // the live server: Basic Auth (username + token as password) gets a
+        // 401 even with a valid token, Bearer auth gets 200. A real external
+        // consumer copying the *username+password*-shaped snippet from
+        // b.well's own internal docs/monorepo would hit this exact 401 with
+        // an otherwise-valid token - use header auth instead.
+        maven {
+            name = "validic"
+            url = uri("https://artifacts.bwell.com/artifactory/virtual-maven")
+            credentials(HttpHeaderCredentials::class) {
+                name = "Authorization"
+                value = "Bearer ${System.getenv("JFROG_READ_TOKEN") ?: "REPLACE_ME"}"
+            }
+            authentication {
+                create<HttpHeaderAuthentication>("header")
+            }
+            content {
+                includeGroup("com.validic.mobile")
+                includeGroup("com.validic")
+            }
+        }
+    }
+}

--- a/bwell-kotlin-android/settings.gradle.kts
+++ b/bwell-kotlin-android/settings.gradle.kts
@@ -18,5 +18,13 @@ dependencyResolutionManagement {
     }
 }
 
+// Health Sync on-device adapter local test overlay - see
+// healthsync-local.settings.gradle.kts.example. Declares the adapter's own
+// JFrog repo + the gated vendor repo (via a second, additive
+// dependencyResolutionManagement { repositories { ... } } block inside the
+// applied file) ONLY when a developer has created this file locally; a
+// fresh clone declares no vendor/gated repository at all.
+file("healthsync-local.settings.gradle.kts").takeIf { it.exists() }?.let { apply(from = it) }
+
 rootProject.name = "MyTestApp"
 include(":app")


### PR DESCRIPTION
## Summary
- Ports the Swift Health Sync Playground+Dashboard to Kotlin/Compose in `bwell-kotlin-android`, mirroring `HealthSyncPlaygroundRootView`'s branch on adapter configuration
- Adds `com.bwell:bwell-sdk-kotlin-healthsync:1.20.0` as the only new committed dependency - vendor-neutral, no adapter/Validic coordinate or gated repo anywhere in git (verified via clean-clone build + grep)
- Gitignored local overlay (`healthsync-local.*.gradle.kts.example` templates + a source-set swap in `app/build.gradle.kts`) lets a developer plug in the published adapter 1.20.0 to test/record demos locally, without ever committing a vendor dependency or binary
- Not-configured state: Playground only, with the 5 adapter-dependent Mobile Sync cards (connect/disconnect/requestPermissions/sync/getCurrentUser) pre-emptively disabled ("Blocked") rather than tappable-then-erroring, using the locked vendor-neutral copy
- Configured state: Dashboard (Metrics/Body Score/Playground tabs), including a temporary public-API-only session-reconciliation workaround for DCON-4936 (not yet in any bwell-sdk-kotlin release)

## Notable findings from this work
- The adapter's published POM declares `com.validic.mobile:*` at **runtime** scope - confirmed a naive committed dependency would break `assembleDebug` for every credential-less clone, not just the Health Sync feature
- The gated Validic repo (`artifacts.bwell.com/artifactory/virtual-maven`) requires **Bearer** auth for JFrog reference tokens - the internal monorepo's own `settings.gradle.kts` snippet uses Basic Auth (username+password), which returns 401 for this token type even when valid. Documented in the `.example` template's header comment
- `BWellHealthSync.configure()` requires `BWellSdk.initialize()` to have already run (documented in its own KDoc) - since this app's drawer makes Health Sync reachable before login, `HealthSyncAdapterBridge.configureIfAvailable()` (local-only file) wraps the call so an early visit just leaves it unconfigured rather than crashing; it self-heals on the next Fragment recreation after login

## Test plan
- [x] Clean-clone `assembleDebug` succeeds with no credentials, no overlay present
- [x] `git grep -iE "validic|artifactory|adapter-aggregator"` over the committed tree returns zero hits
- [x] With the local overlay + real JFrog credentials, `:app:dependencies` resolves the adapter and both `com.validic.mobile:*` artifacts; `assembleDebug` succeeds
- [x] Emulator smoke test (neutral mode): drawer → Health Sync lands on the Playground directly; the 5 gated cards show "Blocked"; `setupMobileSync`/`getDeviceUserStatus`/Cloud Providers/Read Data all render and fail gracefully pre-login; no crash
- [x] Emulator smoke test (overlay mode): adapter resolves and links; pre-login visit to Health Sync no longer crashes (fixed `configureIfAvailable` crash found during this pass); full Dashboard rendering post-login needs a real b.well account and is left for the demo-video pass